### PR TITLE
Fix README setup instructions directory typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A professional web-based trading bot for Binance Futures with real-time monitori
 
 ```bash
 git clone https://github.com/gregorbc/binance-python.git
-cd bbinance-python
+cd binance-python
 ```
 
 ### 2. Environment Configuration


### PR DESCRIPTION
## Summary
- correct the README quick start instructions to change into the cloned project directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ae97de348329818010b7813e8a4a