### PR TITLE
Add lightweight trading helpers for unit tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,16 +25,16 @@ Fecha: 2024
 ═══════════════════════════════════════════════════════════════════
 """
 
-import os
-import time
-import math
-import logging
-import threading
 import csv
-from dataclasses import dataclass, asdict
-from typing import Dict, List, Optional, Tuple
-from datetime import datetime
+import logging
+import math
+import os
+import threading
+import time
 import warnings
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
 
 try:
     import requests
@@ -54,6 +54,7 @@ except ImportError:  # pragma: no cover - numerical analytics optional
 try:
     import psutil
 except ImportError:  # pragma: no cover - provide lightweight fallback for tests
+
     class _PsutilFallback:
         """Minimal psutil substitute used in the unit tests."""
 
@@ -74,12 +75,14 @@ warnings.filterwarnings("ignore")
 try:
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - configuration loading optional
+
     def load_dotenv(*_args, **_kwargs):
         return False
 
+
 try:
     from binance.client import Client
-    from binance.enums import SIDE_BUY, SIDE_SELL, FUTURE_ORDER_TYPE_MARKET
+    from binance.enums import FUTURE_ORDER_TYPE_MARKET, SIDE_BUY, SIDE_SELL
     from binance.exceptions import BinanceAPIException
 except ImportError:  # pragma: no cover - provide lightweight fallbacks for tests
     Client = object
@@ -92,10 +95,11 @@ except ImportError:  # pragma: no cover - provide lightweight fallbacks for test
             super().__init__(message)
             self.code = code
 
+
 try:
-    from flask import Flask, render_template, jsonify, request
-    from flask_socketio import SocketIO
+    from flask import Flask, jsonify, render_template, request
     from flask_cors import CORS
+    from flask_socketio import SocketIO
 except ImportError:  # pragma: no cover - minimal web stubs for tests
     Flask = None
 
@@ -131,16 +135,18 @@ except ImportError:  # pragma: no cover - minimal web stubs for tests
     def CORS(_app, *args, **kwargs):  # pylint: disable=unused-argument
         return _app
 
+
 # ═══════════════════════════════════════════════════════════════════
 # CONFIGURACIÓN DE FLASK
 # ═══════════════════════════════════════════════════════════════════
 
 if Flask is not None:
-    app = Flask(__name__, static_folder='static', template_folder='templates')
-    app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'bot-trading-2024')
+    app = Flask(__name__, static_folder="static", template_folder="templates")
+    app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "bot-trading-2024")
     CORS(app)
-    socketio = SocketIO(app, async_mode='threading', cors_allowed_origins="*")
+    socketio = SocketIO(app, async_mode="threading", cors_allowed_origins="*")
 else:  # pragma: no cover - lightweight stand-in for unit tests
+
     class _FallbackApp:
         def __init__(self):
             self.config = {}
@@ -152,72 +158,82 @@ else:  # pragma: no cover - lightweight stand-in for unit tests
             return decorator
 
     app = _FallbackApp()
-    app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'bot-trading-2024')
-    socketio = SocketIO(app, async_mode='threading', cors_allowed_origins="*")
+    app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "bot-trading-2024")
+    socketio = SocketIO(app, async_mode="threading", cors_allowed_origins="*")
 
 # ═══════════════════════════════════════════════════════════════════
 # CONFIGURACIÓN PRINCIPAL MEJORADA
 # ═══════════════════════════════════════════════════════════════════
 
+
 @dataclass
 class CONFIG:
     """Configuración optimizada del bot"""
-    
+
     # Trading básico
     LEVERAGE: int = 20
     MAX_CONCURRENT_POS: int = 5
     RISK_PER_TRADE_PERCENT: float = 2.0
-    
+
     # Señales
     MIN_SIGNAL_SCORE: int = 4
     MIN_SIGNAL_STRENGTH: float = 0.10
-    
+
     # Stop Loss y Take Profit
     USE_DYNAMIC_SL_TP: bool = True
-    
+
     # Trailing Stop
     TRAILING_STOP_ENABLED: bool = True
     TRAILING_STOP_ACTIVATION: float = 0.5
     TRAILING_STOP_DISTANCE: float = 0.3
-    
+
     # Indicadores
     FAST_EMA: int = 8
     SLOW_EMA: int = 21
     EMA_TREND: int = 50
     RSI_PERIOD: int = 14
     ATR_PERIOD: int = 14
-    
+
     # Filtros
     MIN_24H_VOLUME: float = 10_000_000
     MIN_BALANCE_THRESHOLD: float = 5.0
-    
+
     # Símbolos prioritarios
     PRIORITY_SYMBOLS: tuple = (
-        'BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'ADAUSDT',
-        'XRPUSDT', 'DOTUSDT', 'MATICUSDT', 'AVAXUSDT', 'LINKUSDT'
+        "BTCUSDT",
+        "ETHUSDT",
+        "BNBUSDT",
+        "SOLUSDT",
+        "ADAUSDT",
+        "XRPUSDT",
+        "DOTUSDT",
+        "MATICUSDT",
+        "AVAXUSDT",
+        "LINKUSDT",
     )
-    
+
     # Sistema
     TIMEFRAME: str = "5m"
     CANDLES_LIMIT: int = 100
     POLL_SEC: float = 10.0
     DRY_RUN: bool = False
-    
+
     # Nuevas configuraciones avanzadas
     TRADING_HOURS: str = "00-24"  # 24/7
     MAX_DRAWDOWN_PCT: float = 10.0
     AUTO_RISK_ADJUSTMENT: bool = True
     ENABLE_PYRAMIDING: bool = True
     MAX_PYRAMID_LEVELS: int = 2
-    
+
     # IA y Analytics
     ENABLE_AI_ANALYSIS: bool = True
     SAVE_TRADE_CSV: bool = True
     PERFORMANCE_REPORT_INTERVAL: int = 50
-    
+
     # Logging
     LOG_LEVEL: str = "DEBUG"
     LOG_FILE: str = "bot_v14_advanced.log"
+
 
 config = CONFIG()
 
@@ -239,76 +255,96 @@ class CandlePatterns:
     """Colección de patrones de velas utilizados en los tests."""
 
     def _body(self, candle: Dict[str, float]) -> float:
-        return abs(candle['close'] - candle['open'])
+        return abs(candle["close"] - candle["open"])
 
     def _upper_wick(self, candle: Dict[str, float]) -> float:
-        return candle['high'] - max(candle['open'], candle['close'])
+        return candle["high"] - max(candle["open"], candle["close"])
 
     def _lower_wick(self, candle: Dict[str, float]) -> float:
-        return min(candle['open'], candle['close']) - candle['low']
+        return min(candle["open"], candle["close"]) - candle["low"]
 
-    def is_bullish_engulfing(self, current: Dict[str, float], previous: Dict[str, float]) -> bool:
-        if previous['close'] >= previous['open']:
+    def is_bullish_engulfing(
+        self, current: Dict[str, float], previous: Dict[str, float]
+    ) -> bool:
+        if previous["close"] >= previous["open"]:
             return False
-        if current['close'] <= current['open']:
+        if current["close"] <= current["open"]:
             return False
-        return current['open'] <= previous['close'] and current['close'] >= previous['open']
+        return (
+            current["open"] <= previous["close"]
+            and current["close"] >= previous["open"]
+        )
 
-    def is_bearish_engulfing(self, current: Dict[str, float], previous: Dict[str, float]) -> bool:
-        if previous['close'] <= previous['open']:
+    def is_bearish_engulfing(
+        self, current: Dict[str, float], previous: Dict[str, float]
+    ) -> bool:
+        if previous["close"] <= previous["open"]:
             return False
-        if current['close'] >= current['open']:
+        if current["close"] >= current["open"]:
             return False
-        return current['open'] >= previous['close'] and current['close'] <= previous['open']
+        return (
+            current["open"] >= previous["close"]
+            and current["close"] <= previous["open"]
+        )
 
     def is_hammer(self, candle: Dict[str, float]) -> bool:
         body = self._body(candle)
-        if candle['close'] <= candle['open']:
+        if candle["close"] <= candle["open"]:
             return False
         lower_wick = self._lower_wick(candle)
         upper_wick = self._upper_wick(candle)
-        total_range = candle['high'] - candle['low']
+        total_range = candle["high"] - candle["low"]
         if total_range == 0:
             return False
-        return lower_wick >= body * 2 and upper_wick < body * 0.8 and body / total_range <= 0.4
+        return (
+            lower_wick >= body * 2
+            and upper_wick < body * 0.8
+            and body / total_range <= 0.4
+        )
 
     def is_shooting_star(self, candle: Dict[str, float]) -> bool:
         body = self._body(candle)
-        if candle['close'] >= candle['open']:
+        if candle["close"] >= candle["open"]:
             return False
         upper_wick = self._upper_wick(candle)
         lower_wick = self._lower_wick(candle)
-        total_range = candle['high'] - candle['low']
+        total_range = candle["high"] - candle["low"]
         if total_range == 0:
             return False
-        return upper_wick >= body * 2 and lower_wick < body * 0.8 and body / total_range <= 0.4
+        return (
+            upper_wick >= body * 2
+            and lower_wick < body * 0.8
+            and body / total_range <= 0.4
+        )
 
     def is_pin_bar_bullish(self, candle: Dict[str, float]) -> bool:
         body = self._body(candle)
         lower_wick = self._lower_wick(candle)
         upper_wick = self._upper_wick(candle)
-        total_range = candle['high'] - candle['low']
+        total_range = candle["high"] - candle["low"]
         if total_range == 0:
             return False
         return (
-            candle['close'] >= candle['open']
+            candle["close"] >= candle["open"]
             and lower_wick >= body * 2.5
             and upper_wick <= body
-            and max(candle['open'], candle['close']) >= candle['high'] - total_range * 0.2
+            and max(candle["open"], candle["close"])
+            >= candle["high"] - total_range * 0.2
         )
 
     def is_pin_bar_bearish(self, candle: Dict[str, float]) -> bool:
         body = self._body(candle)
         upper_wick = self._upper_wick(candle)
         lower_wick = self._lower_wick(candle)
-        total_range = candle['high'] - candle['low']
+        total_range = candle["high"] - candle["low"]
         if total_range == 0:
             return False
         return (
-            candle['close'] <= candle['open']
+            candle["close"] <= candle["open"]
             and upper_wick >= body * 2.5
             and lower_wick <= body
-            and min(candle['open'], candle['close']) <= candle['low'] + total_range * 0.2
+            and min(candle["open"], candle["close"])
+            <= candle["low"] + total_range * 0.2
         )
 
 
@@ -316,15 +352,18 @@ class CandlePatterns:
 # LOGGING MEJORADO
 # ═══════════════════════════════════════════════════════════════════
 
+
 class SocketIOHandler(logging.Handler):
     """Handler para emitir logs via Socket.IO"""
+
     def emit(self, record):
         try:
             log_entry = self.format(record)
             level = record.levelname.lower()
-            socketio.emit('log_update', {'message': log_entry, 'level': level})
+            socketio.emit("log_update", {"message": log_entry, "level": level})
         except:
             pass
+
 
 # Configurar logger
 log = logging.getLogger("BinanceFuturesBot")
@@ -332,40 +371,41 @@ log.setLevel(getattr(logging, config.LOG_LEVEL))
 
 if not log.handlers:
     formatter = logging.Formatter(
-        '%(asctime)s | %(levelname)-8s | %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        "%(asctime)s | %(levelname)-8s | %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
-    
-    os.makedirs('logs', exist_ok=True)
-    file_handler = logging.FileHandler(f'logs/{config.LOG_FILE}', encoding='utf-8')
+
+    os.makedirs("logs", exist_ok=True)
+    file_handler = logging.FileHandler(
+        f"logs/{config.LOG_FILE}", encoding="utf-8")
     file_handler.setFormatter(formatter)
-    
+
     socket_handler = SocketIOHandler()
     socket_handler.setFormatter(formatter)
-    
+
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
-    
+
     log.addHandler(file_handler)
     log.addHandler(socket_handler)
     log.addHandler(console_handler)
 
 # Silenciar otros loggers
-for logger_name in ['binance', 'engineio', 'socketio', 'werkzeug', 'urllib3']:
+for logger_name in ["binance", "engineio", "socketio", "werkzeug", "urllib3"]:
     logging.getLogger(logger_name).setLevel(logging.WARNING)
 
 # ═══════════════════════════════════════════════════════════════════
 # MANEJADOR AVANZADO DE ERRORES
 # ═══════════════════════════════════════════════════════════════════
 
+
 class AdvancedErrorHandler:
     """Manejo avanzado de errores con circuit breaker"""
-    
+
     def __init__(self):
         self.error_count = 0
         self.last_error_time = 0
         self.circuit_open = False
-        
+
     def should_retry(self, error):
         """Decidir si reintentar basado en el tipo de error"""
         if isinstance(error, BinanceAPIException):
@@ -374,317 +414,397 @@ class AdvancedErrorHandler:
             if error.code in [-1013, -2010, -2011]:  # Filtros, fondos insuficientes
                 return False
         return True
-    
+
     def record_error(self):
         """Registrar error y posiblemente abrir circuito"""
         self.error_count += 1
         self.last_error_time = time.time()
-        
+
         if self.error_count > 5:
             self.circuit_open = True
             log.warning("🚨 Circuit breaker activado - pausando operaciones")
-    
+
     def record_success(self):
         """Resetear contadores en éxito"""
         self.error_count = 0
         self.circuit_open = False
 
+
 # ═══════════════════════════════════════════════════════════════════
 # MONITOR DE SALUD (CORREGIDO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class HealthMonitor:
     """Monitor de salud del sistema"""
-    
+
     def __init__(self):
         self.metrics = {
-            'api_calls': 0,
-            'errors': 0,
-            'positions_opened': 0,
-            'positions_closed': 0,
-            'signals_detected': 0,
-            'trades_won': 0,
-            'trades_lost': 0,
-            'ai_analysis': 0
+            "api_calls": 0,
+            "errors": 0,
+            "positions_opened": 0,
+            "positions_closed": 0,
+            "signals_detected": 0,
+            "trades_won": 0,
+            "trades_lost": 0,
+            "ai_analysis": 0,
         }
         self.start_time = time.time()
         self.market_volatility = 0
-    
+
     def record_metric(self, metric_name, value=1):
         """Registrar métrica"""
         if metric_name in self.metrics:
             self.metrics[metric_name] += value
-    
+
     def get_uptime(self):
         """Obtener tiempo de actividad"""
         return time.time() - self.start_time
-    
+
     def get_health_status(self):
         """Obtener estado de salud (MEJORADO)"""
         try:
             uptime = self.get_uptime()
-            
+
             # Métricas con protección completa
-            api_calls = max(self.metrics['api_calls'], 1)
-            errors = self.metrics['errors']
+            api_calls = max(self.metrics["api_calls"], 1)
+            errors = self.metrics["errors"]
             error_rate = min(errors / api_calls, 1.0)  # Máximo 100%
-            
-            total_trades = self.metrics['trades_won'] + self.metrics['trades_lost']
-            win_rate = self.metrics['trades_won'] / max(total_trades, 1)
-            
-            signals_per_hour = self.metrics['signals_detected'] / max(uptime / 3600, 0.001)
-            
+
+            total_trades = self.metrics["trades_won"] + \
+                self.metrics["trades_lost"]
+            win_rate = self.metrics["trades_won"] / max(total_trades, 1)
+
+            signals_per_hour = self.metrics["signals_detected"] / max(
+                uptime / 3600, 0.001
+            )
+
             return {
-                'uptime': uptime,
-                'error_rate': error_rate,
-                'win_rate': win_rate,
-                'signals_per_hour': signals_per_hour,
-                'market_volatility': self.market_volatility,
-                'metrics': self.metrics.copy()
+                "uptime": uptime,
+                "error_rate": error_rate,
+                "win_rate": win_rate,
+                "signals_per_hour": signals_per_hour,
+                "market_volatility": self.market_volatility,
+                "metrics": self.metrics.copy(),
             }
         except Exception as e:
             log.error(f"Error calculando health status: {e}")
             return {
-                'uptime': 0,
-                'error_rate': 1.0,
-                'win_rate': 0.0,
-                'signals_per_hour': 0.0,
-                'market_volatility': 0,
-                'metrics': self.metrics.copy()
+                "uptime": 0,
+                "error_rate": 1.0,
+                "win_rate": 0.0,
+                "signals_per_hour": 0.0,
+                "market_volatility": 0,
+                "metrics": self.metrics.copy(),
             }
+
 
 # ═══════════════════════════════════════════════════════════════════
 # SISTEMA AVANZADO DE LOGS Y ANÁLISIS (NUEVO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class AdvancedTradeLogger:
     """Sistema avanzado de logging y análisis de trades"""
-    
+
     def __init__(self):
         self.trade_history = []
         self.performance_metrics = {}
         self.best_trades = []
         self.worst_trades = []
-        
+
     def log_trade_detailed(self, trade_data):
         """Guardar trade con análisis detallado"""
         detailed_trade = {
             **trade_data,
-            'timestamp': datetime.now().isoformat(),
-            'market_condition': app_state.get("market_condition", "NORMAL"),
-            'volatility': getattr(health_monitor, 'market_volatility', 0),
-            'signal_score': trade_data.get('signal_score', 0),
-            'risk_adjustment': trade_data.get('risk_adjustment', 1.0)
+            "timestamp": datetime.now().isoformat(),
+            "market_condition": app_state.get("market_condition", "NORMAL"),
+            "volatility": getattr(health_monitor, "market_volatility", 0),
+            "signal_score": trade_data.get("signal_score", 0),
+            "risk_adjustment": trade_data.get("risk_adjustment", 1.0),
         }
-        
+
         self.trade_history.append(detailed_trade)
-        
+
         # Mantener ordenados los mejores/peores trades
         self._update_best_worst_trades(detailed_trade)
-        
+
         # Guardar en archivo
         if config.SAVE_TRADE_CSV:
             self._save_to_csv(detailed_trade)
-        
+
         # Análisis en tiempo real
         self._real_time_analysis(detailed_trade)
-        
-        log.info(f"📊 Trade analizado: {trade_data['symbol']} | "
-                f"P&L: {trade_data.get('pnl', 0):+.2f} | "
-                f"Score: {trade_data.get('signal_score', 0)}/8")
-    
+
+        log.info(
+            f"📊 Trade analizado: {trade_data['symbol']} | "
+            f"P&L: {trade_data.get('pnl', 0):+.2f} | "
+            f"Score: {trade_data.get('signal_score', 0)}/8"
+        )
+
     def _update_best_worst_trades(self, trade):
         """Actualizar lista de mejores y peores trades"""
-        if trade.get('pnl', 0) > 0:
+        if trade.get("pnl", 0) > 0:
             self.best_trades.append(trade)
-            self.best_trades.sort(key=lambda x: x.get('pnl', 0), reverse=True)
+            self.best_trades.sort(key=lambda x: x.get("pnl", 0), reverse=True)
             self.best_trades = self.best_trades[:10]  # Top 10
         else:
             self.worst_trades.append(trade)
-            self.worst_trades.sort(key=lambda x: x.get('pnl', 0))
+            self.worst_trades.sort(key=lambda x: x.get("pnl", 0))
             self.worst_trades = self.worst_trades[:10]  # Peores 10
-    
+
     def _save_to_csv(self, trade_data):
         """Guardar trade en CSV para análisis posterior"""
         try:
             filename = f"logs/trade_analysis_{datetime.now().strftime('%Y%m')}.csv"
-            os.makedirs('logs', exist_ok=True)
-            
+            os.makedirs("logs", exist_ok=True)
+
             file_exists = os.path.isfile(filename)
-            
-            with open(filename, 'a', newline='', encoding='utf-8') as f:
-                writer = csv.DictWriter(f, fieldnames=[
-                    'timestamp', 'symbol', 'side', 'entry_price', 'exit_price',
-                    'quantity', 'pnl', 'duration', 'signal_score', 'market_condition',
-                    'volatility', 'risk_adjustment', 'exit_reason'
-                ])
-                
+
+            with open(filename, "a", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(
+                    f,
+                    fieldnames=[
+                        "timestamp",
+                        "symbol",
+                        "side",
+                        "entry_price",
+                        "exit_price",
+                        "quantity",
+                        "pnl",
+                        "duration",
+                        "signal_score",
+                        "market_condition",
+                        "volatility",
+                        "risk_adjustment",
+                        "exit_reason",
+                    ],
+                )
+
                 if not file_exists:
                     writer.writeheader()
-                
-                writer.writerow({
-                    'timestamp': trade_data['timestamp'],
-                    'symbol': trade_data['symbol'],
-                    'side': trade_data['side'],
-                    'entry_price': trade_data.get('entry_price', 0),
-                    'exit_price': trade_data.get('exit_price', 0),
-                    'quantity': trade_data.get('quantity', 0),
-                    'pnl': trade_data.get('pnl', 0),
-                    'duration': trade_data.get('duration', 0),
-                    'signal_score': trade_data.get('signal_score', 0),
-                    'market_condition': trade_data.get('market_condition', 'NORMAL'),
-                    'volatility': trade_data.get('volatility', 0),
-                    'risk_adjustment': trade_data.get('risk_adjustment', 1.0),
-                    'exit_reason': trade_data.get('reason', 'Unknown')
-                })
+
+                writer.writerow(
+                    {
+                        "timestamp": trade_data["timestamp"],
+                        "symbol": trade_data["symbol"],
+                        "side": trade_data["side"],
+                        "entry_price": trade_data.get("entry_price", 0),
+                        "exit_price": trade_data.get("exit_price", 0),
+                        "quantity": trade_data.get("quantity", 0),
+                        "pnl": trade_data.get("pnl", 0),
+                        "duration": trade_data.get("duration", 0),
+                        "signal_score": trade_data.get("signal_score", 0),
+                        "market_condition": trade_data.get(
+                            "market_condition", "NORMAL"
+                        ),
+                        "volatility": trade_data.get("volatility", 0),
+                        "risk_adjustment": trade_data.get("risk_adjustment", 1.0),
+                        "exit_reason": trade_data.get("reason", "Unknown"),
+                    }
+                )
         except Exception as e:
             log.error(f"Error guardando CSV: {e}")
-    
+
     def _real_time_analysis(self, trade):
         """Análisis en tiempo real del trade"""
         try:
             # Análisis de patrones
-            pnl = trade.get('pnl', 0)
-            score = trade.get('signal_score', 0)
-            
+            pnl = trade.get("pnl", 0)
+            score = trade.get("signal_score", 0)
+
             if pnl > 0 and score >= 6:
-                log.info(f"🎯 PATRÓN EXITOSO: Score alto ({score}) = P&L positivo")
+                log.info(
+                    f"🎯 PATRÓN EXITOSO: Score alto ({score}) = P&L positivo")
             elif pnl < 0 and score >= 6:
-                log.warning(f"⚠️ PATRÓN INESPERADO: Score alto ({score}) = P&L negativo")
+                log.warning(
+                    f"⚠️ PATRÓN INESPERADO: Score alto ({score}) = P&L negativo")
             elif pnl > 0 and score <= 4:
-                log.info(f"🎯 SORPRESA POSITIVA: Score bajo ({score}) = P&L positivo")
-                
+                log.info(
+                    f"🎯 SORPRESA POSITIVA: Score bajo ({score}) = P&L positivo")
+
         except Exception as e:
             log.error(f"Error en análisis en tiempo real: {e}")
-    
+
     def get_performance_analysis(self):
         """Obtener análisis de performance completo"""
         if not self.trade_history:
             return {}
-        
+
         try:
             df = pd.DataFrame(self.trade_history)
-            
+
             # Métricas básicas
             total_trades = len(df)
-            winning_trades = df[df['pnl'] > 0]
-            losing_trades = df[df['pnl'] < 0]
-            
-            win_rate = len(winning_trades) / total_trades * 100 if total_trades > 0 else 0
-            avg_win = winning_trades['pnl'].mean() if not winning_trades.empty else 0
-            avg_loss = losing_trades['pnl'].mean() if not losing_trades.empty else 0
-            
+            winning_trades = df[df["pnl"] > 0]
+            losing_trades = df[df["pnl"] < 0]
+
+            win_rate = (
+                len(winning_trades) / total_trades *
+                100 if total_trades > 0 else 0
+            )
+            avg_win = winning_trades["pnl"].mean(
+            ) if not winning_trades.empty else 0
+            avg_loss = losing_trades["pnl"].mean(
+            ) if not losing_trades.empty else 0
+
             # Análisis por condiciones de mercado
-            normal_trades = df[df['market_condition'] == 'NORMAL']
-            high_vol_trades = df[df['market_condition'] == 'HIGH_VOLATILITY']
-            low_vol_trades = df[df['market_condition'] == 'LOW_VOLATILITY']
-            
+            normal_trades = df[df["market_condition"] == "NORMAL"]
+            high_vol_trades = df[df["market_condition"] == "HIGH_VOLATILITY"]
+            low_vol_trades = df[df["market_condition"] == "LOW_VOLATILITY"]
+
             return {
-                'summary': {
-                    'total_trades': total_trades,
-                    'win_rate': win_rate,
-                    'avg_win': avg_win,
-                    'avg_loss': avg_loss,
-                    'profit_factor': abs(winning_trades['pnl'].sum() / losing_trades['pnl'].sum()) if not losing_trades.empty else float('inf'),
-                    'total_pnl': df['pnl'].sum()
+                "summary": {
+                    "total_trades": total_trades,
+                    "win_rate": win_rate,
+                    "avg_win": avg_win,
+                    "avg_loss": avg_loss,
+                    "profit_factor": (
+                        abs(winning_trades["pnl"].sum() /
+                            losing_trades["pnl"].sum())
+                        if not losing_trades.empty
+                        else float("inf")
+                    ),
+                    "total_pnl": df["pnl"].sum(),
                 },
-                'market_analysis': {
-                    'normal_condition': {
-                        'trades': len(normal_trades),
-                        'win_rate': len(normal_trades[normal_trades['pnl'] > 0]) / len(normal_trades) * 100 if len(normal_trades) > 0 else 0,
-                        'avg_pnl': normal_trades['pnl'].mean() if not normal_trades.empty else 0
+                "market_analysis": {
+                    "normal_condition": {
+                        "trades": len(normal_trades),
+                        "win_rate": (
+                            len(normal_trades[normal_trades["pnl"] > 0])
+                            / len(normal_trades)
+                            * 100
+                            if len(normal_trades) > 0
+                            else 0
+                        ),
+                        "avg_pnl": (
+                            normal_trades["pnl"].mean()
+                            if not normal_trades.empty
+                            else 0
+                        ),
                     },
-                    'high_volatility': {
-                        'trades': len(high_vol_trades),
-                        'win_rate': len(high_vol_trades[high_vol_trades['pnl'] > 0]) / len(high_vol_trades) * 100 if len(high_vol_trades) > 0 else 0,
-                        'avg_pnl': high_vol_trades['pnl'].mean() if not high_vol_trades.empty else 0
+                    "high_volatility": {
+                        "trades": len(high_vol_trades),
+                        "win_rate": (
+                            len(high_vol_trades[high_vol_trades["pnl"] > 0])
+                            / len(high_vol_trades)
+                            * 100
+                            if len(high_vol_trades) > 0
+                            else 0
+                        ),
+                        "avg_pnl": (
+                            high_vol_trades["pnl"].mean()
+                            if not high_vol_trades.empty
+                            else 0
+                        ),
                     },
-                    'low_volatility': {
-                        'trades': len(low_vol_trades),
-                        'win_rate': len(low_vol_trades[low_vol_trades['pnl'] > 0]) / len(low_vol_trades) * 100 if len(low_vol_trades) > 0 else 0,
-                        'avg_pnl': low_vol_trades['pnl'].mean() if not low_vol_trades.empty else 0
-                    }
+                    "low_volatility": {
+                        "trades": len(low_vol_trades),
+                        "win_rate": (
+                            len(low_vol_trades[low_vol_trades["pnl"] > 0])
+                            / len(low_vol_trades)
+                            * 100
+                            if len(low_vol_trades) > 0
+                            else 0
+                        ),
+                        "avg_pnl": (
+                            low_vol_trades["pnl"].mean()
+                            if not low_vol_trades.empty
+                            else 0
+                        ),
+                    },
                 },
-                'signal_analysis': self._analyze_signal_performance(df),
-                'best_trades': self.best_trades[:5],
-                'worst_trades': self.worst_trades[:5]
+                "signal_analysis": self._analyze_signal_performance(df),
+                "best_trades": self.best_trades[:5],
+                "worst_trades": self.worst_trades[:5],
             }
         except Exception as e:
             log.error(f"Error en análisis de performance: {e}")
             return {}
-    
+
     def _analyze_signal_performance(self, df):
         """Analizar performance por score de señal"""
         signal_performance = {}
-        
+
         try:
             for score in range(4, 9):  # Scores de 4 a 8
-                score_trades = df[df['signal_score'] == score]
+                score_trades = df[df["signal_score"] == score]
                 if not score_trades.empty:
-                    win_rate = len(score_trades[score_trades['pnl'] > 0]) / len(score_trades) * 100
-                    avg_pnl = score_trades['pnl'].mean()
-                    signal_performance[f'score_{score}'] = {
-                        'trades': len(score_trades),
-                        'win_rate': win_rate,
-                        'avg_pnl': avg_pnl
+                    win_rate = (
+                        len(score_trades[score_trades["pnl"] > 0])
+                        / len(score_trades)
+                        * 100
+                    )
+                    avg_pnl = score_trades["pnl"].mean()
+                    signal_performance[f"score_{score}"] = {
+                        "trades": len(score_trades),
+                        "win_rate": win_rate,
+                        "avg_pnl": avg_pnl,
                     }
         except Exception as e:
             log.error(f"Error analizando señales: {e}")
-        
+
         return signal_performance
+
 
 # ═══════════════════════════════════════════════════════════════════
 # SISTEMA DE IA PARA OPTIMIZACIÓN (NUEVO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class TradingAI:
     """Sistema de IA para optimización de trades"""
-    
+
     def __init__(self):
         self.learning_data = []
         self.patterns_detected = []
         self.model_weights = {
-            'ema_cross': 1.0,
-            'rsi': 1.0,
-            'macd': 1.0,
-            'volume': 1.0,
-            'momentum': 1.0,
-            'market_condition': 1.0
+            "ema_cross": 1.0,
+            "rsi": 1.0,
+            "macd": 1.0,
+            "volume": 1.0,
+            "momentum": 1.0,
+            "market_condition": 1.0,
         }
-    
+
     def analyze_trade_pattern(self, trade_data, market_condition):
         """Analizar patrones del trade usando IA simple"""
         try:
-            health_monitor.record_metric('ai_analysis')
-            
+            health_monitor.record_metric("ai_analysis")
+
             # Factores de análisis
             factors = {
-                'duration': trade_data.get('duration', 0),
-                'pnl_percentage': (trade_data.get('pnl', 0) / trade_data.get('entry_price', 1)) * 100,
-                'signal_score': trade_data.get('signal_score', 0),
-                'market_condition': market_condition,
-                'exit_reason': trade_data.get('reason', 'Unknown')
+                "duration": trade_data.get("duration", 0),
+                "pnl_percentage": (
+                    trade_data.get("pnl", 0) / trade_data.get("entry_price", 1)
+                )
+                * 100,
+                "signal_score": trade_data.get("signal_score", 0),
+                "market_condition": market_condition,
+                "exit_reason": trade_data.get("reason", "Unknown"),
             }
-            
+
             # Aprendizaje de patrones
-            self._update_model_weights(factors, trade_data.get('pnl', 0))
-            
+            self._update_model_weights(factors, trade_data.get("pnl", 0))
+
             # Detección de patrones recurrentes
             pattern = self._detect_pattern(factors)
             if pattern:
-                self.patterns_detected.append({
-                    'pattern': pattern,
-                    'timestamp': datetime.now().isoformat(),
-                    'factors': factors
-                })
+                self.patterns_detected.append(
+                    {
+                        "pattern": pattern,
+                        "timestamp": datetime.now().isoformat(),
+                        "factors": factors,
+                    }
+                )
                 log.info(f"🤖 IA detectó patrón: {pattern}")
-            
+
             return factors
-            
+
         except Exception as e:
             log.error(f"Error en análisis IA: {e}")
             return {}
-    
+
     def _update_model_weights(self, factors, pnl):
         """Actualizar pesos del modelo basado en resultados"""
         try:
@@ -695,76 +815,93 @@ class TradingAI:
             else:
                 # Reducir factores negativos
                 adjustment = 0.95
-            
+
             # Ajustar pesos (simplificado)
             for factor in factors:
                 if factor in self.model_weights:
                     self.model_weights[factor] *= adjustment
                     # Limitar pesos
-                    self.model_weights[factor] = max(0.1, min(2.0, self.model_weights[factor]))
-                    
+                    self.model_weights[factor] = max(
+                        0.1, min(2.0, self.model_weights[factor])
+                    )
+
         except Exception as e:
             log.error(f"Error actualizando pesos IA: {e}")
-    
+
     def _detect_pattern(self, factors):
         """Detectar patrones en los trades"""
         try:
             # Patrón: Trades cortos y rentables
-            if (factors['duration'] < 300 and  # menos de 5 minutos
-                factors['pnl_percentage'] > 0.5):
+            if (
+                factors["duration"] < 300  # menos de 5 minutos
+                and factors["pnl_percentage"] > 0.5
+            ):
                 return "SCALPING_EXITOSO"
-            
+
             # Patrón: Trades largos con buen rendimiento
-            if (factors['duration'] > 1800 and  # más de 30 minutos
-                factors['pnl_percentage'] > 1.0):
+            if (
+                factors["duration"] > 1800  # más de 30 minutos
+                and factors["pnl_percentage"] > 1.0
+            ):
                 return "SWING_EXITOSO"
-            
+
             # Patrón: Señales fuertes con buen resultado
-            if (factors['signal_score'] >= 7 and
-                factors['pnl_percentage'] > 0.8):
+            if factors["signal_score"] >= 7 and factors["pnl_percentage"] > 0.8:
                 return "SEÑAL_FUERTE_EXITOSA"
-                
+
             return None
-            
+
         except Exception as e:
             log.error(f"Error detectando patrones: {e}")
             return None
-    
+
     def get_optimization_recommendations(self):
         """Obtener recomendaciones de optimización"""
         recommendations = []
-        
+
         try:
             # Analizar pesos del modelo
             for factor, weight in self.model_weights.items():
                 if weight > 1.5:
-                    recommendations.append(f"✅ Aumentar importancia de {factor}")
+                    recommendations.append(
+                        f"✅ Aumentar importancia de {factor}")
                 elif weight < 0.7:
-                    recommendations.append(f"⚠️ Reducir importancia de {factor}")
-            
+                    recommendations.append(
+                        f"⚠️ Reducir importancia de {factor}")
+
             # Recomendaciones basadas en patrones
             recent_patterns = self.patterns_detected[-5:]  # últimos 5 patrones
-            if any("SCALPING_EXITOSO" in p.get('pattern', '') for p in recent_patterns):
-                recommendations.append("🎯 Estrategia de scalping funcionando bien - considerar timeframe más corto")
-            
-            if any("SEÑAL_FUERTE_EXITOSA" in p.get('pattern', '') for p in recent_patterns):
-                recommendations.append("📈 Considerar aumentar tamaño en señales con score ≥ 7")
-            
-            if any("SWING_EXITOSO" in p.get('pattern', '') for p in recent_patterns):
-                recommendations.append("⏳ Trades swing rentables - ajustar trailing stops más amplios")
-                
+            if any("SCALPING_EXITOSO" in p.get("pattern", "") for p in recent_patterns):
+                recommendations.append(
+                    "🎯 Estrategia de scalping funcionando bien - considerar timeframe más corto"
+                )
+
+            if any(
+                "SEÑAL_FUERTE_EXITOSA" in p.get("pattern", "") for p in recent_patterns
+            ):
+                recommendations.append(
+                    "📈 Considerar aumentar tamaño en señales con score ≥ 7"
+                )
+
+            if any("SWING_EXITOSO" in p.get("pattern", "") for p in recent_patterns):
+                recommendations.append(
+                    "⏳ Trades swing rentables - ajustar trailing stops más amplios"
+                )
+
         except Exception as e:
             log.error(f"Error generando recomendaciones IA: {e}")
-        
+
         return recommendations
+
 
 # ═══════════════════════════════════════════════════════════════════
 # MONITOR DE POSICIONES MEJORADO (NUEVO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class EnhancedPositionMonitor:
     """Monitor avanzado de posiciones con análisis en tiempo real"""
-    
+
     def __init__(self, api, capital_manager):
         self.api = api
         self.capital = capital_manager
@@ -772,493 +909,581 @@ class EnhancedPositionMonitor:
         self.performance_alerts = []
         self.trade_logger = AdvancedTradeLogger()
         self.trading_ai = TradingAI()
-    
+
     def monitor_all_positions(self):
         """Monitoreo completo de todas las posiciones"""
         try:
             account = self.api._safe_api_call(self.api.client.futures_account)
             if not account:
                 return
-            
-            open_positions = {p['symbol']: p for p in account['positions'] 
-                            if float(p['positionAmt']) != 0}
-            
+
+            open_positions = {
+                p["symbol"]: p
+                for p in account["positions"]
+                if float(p["positionAmt"]) != 0
+            }
+
             # Actualizar snapshot
             self._update_positions_snapshot(open_positions)
-            
+
             # Análisis en tiempo real
             for symbol, position in open_positions.items():
                 self._analyze_position_health(symbol, position)
                 self._check_performance_alerts(symbol, position)
-            
+
             # Log de estado
-            if open_positions and len(open_positions) % 5 == 0:  # Log cada 5 posiciones
-                log.info(f"📊 Monitor: {len(open_positions)} posiciones activas")
-                
+            # Log cada 5 posiciones
+            if open_positions and len(open_positions) % 5 == 0:
+                log.info(
+                    f"📊 Monitor: {len(open_positions)} posiciones activas")
+
         except Exception as e:
             log.error(f"Error en monitor de posiciones: {e}")
-    
+
     def _update_positions_snapshot(self, positions):
         """Actualizar snapshot de posiciones para análisis"""
         for symbol, position in positions.items():
-            current_pnl = float(position.get('unRealizedProfit', 0))
-            
+            current_pnl = float(position.get("unRealizedProfit", 0))
+
             if symbol not in self.positions_snapshot:
                 self.positions_snapshot[symbol] = {
-                    'max_pnl': current_pnl,
-                    'min_pnl': current_pnl,
-                    'entry_time': time.time(),
-                    'pnl_history': []
+                    "max_pnl": current_pnl,
+                    "min_pnl": current_pnl,
+                    "entry_time": time.time(),
+                    "pnl_history": [],
                 }
             else:
                 # Actualizar máximos y mínimos
-                self.positions_snapshot[symbol]['max_pnl'] = max(
-                    self.positions_snapshot[symbol]['max_pnl'], current_pnl
+                self.positions_snapshot[symbol]["max_pnl"] = max(
+                    self.positions_snapshot[symbol]["max_pnl"], current_pnl
                 )
-                self.positions_snapshot[symbol]['min_pnl'] = min(
-                    self.positions_snapshot[symbol]['min_pnl'], current_pnl
+                self.positions_snapshot[symbol]["min_pnl"] = min(
+                    self.positions_snapshot[symbol]["min_pnl"], current_pnl
                 )
-            
+
             # Guardar histórico de PnL
-            self.positions_snapshot[symbol]['pnl_history'].append({
-                'timestamp': time.time(),
-                'pnl': current_pnl,
-                'price': float(position.get('markPrice', 0))
-            })
-            
+            self.positions_snapshot[symbol]["pnl_history"].append(
+                {
+                    "timestamp": time.time(),
+                    "pnl": current_pnl,
+                    "price": float(position.get("markPrice", 0)),
+                }
+            )
+
             # Mantener sólo últimas 100 lecturas
-            if len(self.positions_snapshot[symbol]['pnl_history']) > 100:
-                self.positions_snapshot[symbol]['pnl_history'] = \
-                    self.positions_snapshot[symbol]['pnl_history'][-100:]
-    
+            if len(self.positions_snapshot[symbol]["pnl_history"]) > 100:
+                self.positions_snapshot[symbol]["pnl_history"] = (
+                    self.positions_snapshot[symbol]["pnl_history"][-100:]
+                )
+
     def _analyze_position_health(self, symbol, position):
         """Analizar salud de la posición"""
         try:
-            current_pnl = float(position.get('unRealizedProfit', 0))
-            entry_price = float(position.get('entryPrice', 0))
-            mark_price = float(position.get('markPrice', 0))
-            
+            current_pnl = float(position.get("unRealizedProfit", 0))
+            entry_price = float(position.get("entryPrice", 0))
+            mark_price = float(position.get("markPrice", 0))
+
             if symbol in self.positions_snapshot:
                 snapshot = self.positions_snapshot[symbol]
-                max_pnl = snapshot['max_pnl']
-                
+                max_pnl = snapshot["max_pnl"]
+
                 # Calcular drawdown desde máximo
                 drawdown = max_pnl - current_pnl
-                drawdown_pct = (drawdown / abs(max_pnl)) * 100 if max_pnl != 0 else 0
-                
+                drawdown_pct = (drawdown / abs(max_pnl)) * \
+                    100 if max_pnl != 0 else 0
+
                 # Alertas de salud
                 if drawdown_pct > 50:  # 50% drawdown desde máximo
-                    self._add_alert(symbol, f"ALTO DRAWDOWN: {drawdown_pct:.1f}% desde máximo")
-                    log.warning(f"⚠️ {symbol}: Drawdown del {drawdown_pct:.1f}%")
-                
+                    self._add_alert(
+                        symbol, f"ALTO DRAWDOWN: {drawdown_pct:.1f}% desde máximo"
+                    )
+                    log.warning(
+                        f"⚠️ {symbol}: Drawdown del {drawdown_pct:.1f}%")
+
                 # Análisis de tendencia de PnL
-                if len(snapshot['pnl_history']) >= 10:
-                    recent_pnls = [p['pnl'] for p in snapshot['pnl_history'][-10:]]
-                    if all(p < 0 for p in recent_pnls):  # 10 lecturas negativas consecutivas
-                        self._add_alert(symbol, "TENDENCIA NEGATIVA PERSISTENTE")
-                        
+                if len(snapshot["pnl_history"]) >= 10:
+                    recent_pnls = [p["pnl"]
+                                   for p in snapshot["pnl_history"][-10:]]
+                    if all(
+                        p < 0 for p in recent_pnls
+                    ):  # 10 lecturas negativas consecutivas
+                        self._add_alert(
+                            symbol, "TENDENCIA NEGATIVA PERSISTENTE")
+
         except Exception as e:
             log.error(f"Error analizando salud posición {symbol}: {e}")
-    
+
     def _check_performance_alerts(self, symbol, position):
         """Verificar alertas de performance"""
         try:
-            current_pnl = float(position.get('unRealizedProfit', 0))
-            position_amt = float(position.get('positionAmt', 0))
-            
+            current_pnl = float(position.get("unRealizedProfit", 0))
+            position_amt = float(position.get("positionAmt", 0))
+
             # Alertas basadas en PnL
             if current_pnl > 100:  # Ganancia significativa
-                log.info(f"🎯 {symbol}: Ganancia significativa +${current_pnl:.2f}")
-            
+                log.info(
+                    f"🎯 {symbol}: Ganancia significativa +${current_pnl:.2f}")
+
             elif current_pnl < -50:  # Pérdida significativa
-                log.warning(f"⚠️ {symbol}: Pérdida significativa ${current_pnl:.2f}")
-                
+                log.warning(
+                    f"⚠️ {symbol}: Pérdida significativa ${current_pnl:.2f}")
+
         except Exception as e:
             log.error(f"Error verificando alertas {symbol}: {e}")
-    
+
     def _add_alert(self, symbol, message):
         """Agregar alerta al sistema"""
         alert = {
-            'symbol': symbol,
-            'message': message,
-            'timestamp': datetime.now().isoformat(),
-            'priority': 'HIGH' if 'ALTO' in message else 'MEDIUM'
+            "symbol": symbol,
+            "message": message,
+            "timestamp": datetime.now().isoformat(),
+            "priority": "HIGH" if "ALTO" in message else "MEDIUM",
         }
         self.performance_alerts.append(alert)
-        
+
         # Mantener sólo últimas 20 alertas
         if len(self.performance_alerts) > 20:
             self.performance_alerts = self.performance_alerts[-20:]
-    
+
     def log_position_close(self, symbol, position_data, close_info, signal_score=0):
         """Registrar cierre de posición con análisis completo"""
         try:
             trade_data = {
-                'symbol': symbol,
-                'side': position_data.get('side', 'UNKNOWN'),
-                'entry_price': position_data.get('entry', 0),
-                'exit_price': float(position_data.get('markPrice', 0)),
-                'quantity': position_data.get('qty', 0),
-                'pnl': float(position_data.get('unRealizedProfit', 0)),
-                'duration': time.time() - position_data.get('time', time.time()),
-                'signal_score': signal_score,
-                'reason': close_info.get('reason', 'Unknown'),
-                'max_pnl': close_info.get('max_pnl', 0)
+                "symbol": symbol,
+                "side": position_data.get("side", "UNKNOWN"),
+                "entry_price": position_data.get("entry", 0),
+                "exit_price": float(position_data.get("markPrice", 0)),
+                "quantity": position_data.get("qty", 0),
+                "pnl": float(position_data.get("unRealizedProfit", 0)),
+                "duration": time.time() - position_data.get("time", time.time()),
+                "signal_score": signal_score,
+                "reason": close_info.get("reason", "Unknown"),
+                "max_pnl": close_info.get("max_pnl", 0),
             }
-            
+
             # Análisis con IA
             if config.ENABLE_AI_ANALYSIS:
                 market_condition = app_state.get("market_condition", "NORMAL")
-                ai_analysis = self.trading_ai.analyze_trade_pattern(trade_data, market_condition)
-                trade_data['ai_analysis'] = ai_analysis
-            
+                ai_analysis = self.trading_ai.analyze_trade_pattern(
+                    trade_data, market_condition
+                )
+                trade_data["ai_analysis"] = ai_analysis
+
             # Guardar en logger avanzado
             self.trade_logger.log_trade_detailed(trade_data)
-            
+
             # Limpiar snapshot
             self.positions_snapshot.pop(symbol, None)
-            
+
         except Exception as e:
             log.error(f"Error registrando cierre de posición {symbol}: {e}")
+
 
 # ═══════════════════════════════════════════════════════════════════
 # SISTEMA DE BACKTESTING (COMPLETAMENTE CORREGIDO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class Backtester:
     """Sistema de backtesting para optimizar parámetros - VERSIÓN CORREGIDA"""
-    
+
     def __init__(self, api):
         self.api = api
-    
+
     def run_backtest(self, symbol, days=30, params=None):
         """Ejecutar backtest con parámetros específicos - CORREGIDO"""
         try:
             # Obtener datos históricos
             end_time = int(time.time() * 1000)
             start_time = end_time - (days * 24 * 60 * 60 * 1000)
-            
+
             klines = self.api._safe_api_call(
                 self.api.client.futures_klines,
                 symbol=symbol,
                 interval=config.TIMEFRAME,
                 startTime=start_time,
                 endTime=end_time,
-                limit=1000
+                limit=1000,
             )
-            
+
             if not klines:
                 return {"error": "No se pudieron obtener datos históricos"}
-            
-            df = pd.DataFrame(klines, columns=[
-                'timestamp', 'open', 'high', 'low', 'close', 'volume',
-                'close_time', 'quote_volume', 'trades', 'taker_buy', 'taker_quote', 'ignore'
-            ])
-            
-            for col in ['open', 'high', 'low', 'close', 'volume']:
-                df[col] = pd.to_numeric(df[col], errors='coerce')
-            
+
+            df = pd.DataFrame(
+                klines,
+                columns=[
+                    "timestamp",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "close_time",
+                    "quote_volume",
+                    "trades",
+                    "taker_buy",
+                    "taker_quote",
+                    "ignore",
+                ],
+            )
+
+            for col in ["open", "high", "low", "close", "volume"]:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+
             # Simular trading
             results = self._simulate_trading(df, params or {})
             return results
-            
+
         except Exception as e:
             log.error(f"Error en backtest: {e}")
             return {"error": str(e)}
-    
+
     def _simulate_trading(self, df, params):
         """Simular estrategia de trading - COMPLETAMENTE CORREGIDO"""
         try:
             detector = SignalDetector()
             df_indicators = detector.calculate_indicators(df.copy())
-            
+
             if df_indicators is None or len(df_indicators) < 50:
                 return {"error": "Datos insuficientes para backtesting"}
-            
+
             # Simulación mejorada
             initial_balance = 1000  # Balance inicial simulado
             balance = initial_balance
             positions = []
             trades = []
-            
+
             for i in range(50, len(df_indicators)):
-                current_data = df_indicators.iloc[:i+1]
+                current_data = df_indicators.iloc[: i + 1]
                 signal = detector.detect_signal(current_data, "SIMULATION")
-                
+
                 if signal and not positions:  # Solo abrir si no hay posición
                     # Lógica de trading simulada mejorada
-                    price = df_indicators.iloc[i]['close']
-                    
-                    if signal['type'] == 'LONG':
+                    price = df_indicators.iloc[i]["close"]
+
+                    if signal["type"] == "LONG":
                         entry_price = price
                         # Calcular tamaño de posición (1% del balance)
                         position_size = balance * 0.01
                         quantity = position_size / entry_price
-                        positions.append({
-                            'side': 'LONG', 
-                            'entry': entry_price, 
-                            'quantity': quantity,
-                            'entry_idx': i
-                        })
-                        trades.append({
-                            'action': 'BUY', 
-                            'price': entry_price, 
-                            'timestamp': df_indicators.iloc[i]['timestamp'],
-                            'quantity': quantity
-                        })
-                        
-                    elif signal['type'] == 'SHORT':
+                        positions.append(
+                            {
+                                "side": "LONG",
+                                "entry": entry_price,
+                                "quantity": quantity,
+                                "entry_idx": i,
+                            }
+                        )
+                        trades.append(
+                            {
+                                "action": "BUY",
+                                "price": entry_price,
+                                "timestamp": df_indicators.iloc[i]["timestamp"],
+                                "quantity": quantity,
+                            }
+                        )
+
+                    elif signal["type"] == "SHORT":
                         entry_price = price
                         position_size = balance * 0.01
                         quantity = position_size / entry_price
-                        positions.append({
-                            'side': 'SHORT', 
-                            'entry': entry_price,
-                            'quantity': quantity,
-                            'entry_idx': i
-                        })
-                        trades.append({
-                            'action': 'SELL', 
-                            'price': entry_price, 
-                            'timestamp': df_indicators.iloc[i]['timestamp'],
-                            'quantity': quantity
-                        })
-                
+                        positions.append(
+                            {
+                                "side": "SHORT",
+                                "entry": entry_price,
+                                "quantity": quantity,
+                                "entry_idx": i,
+                            }
+                        )
+                        trades.append(
+                            {
+                                "action": "SELL",
+                                "price": entry_price,
+                                "timestamp": df_indicators.iloc[i]["timestamp"],
+                                "quantity": quantity,
+                            }
+                        )
+
                 # Cerrar posiciones existentes
                 if positions:
                     pos = positions[0]
-                    current_price = df_indicators.iloc[i]['close']
-                    
+                    current_price = df_indicators.iloc[i]["close"]
+
                     # Estrategia de salida simple
-                    if pos['side'] == 'LONG':
+                    if pos["side"] == "LONG":
                         # TP: 2%, SL: 1%
-                        if current_price >= pos['entry'] * 1.02 or current_price <= pos['entry'] * 0.99:
-                            pnl_pct = (current_price - pos['entry']) / pos['entry'] * 100
-                            pnl_usdt = pnl_pct * pos['quantity'] * pos['entry'] / 100
-                            trades.append({
-                                'action': 'SELL', 
-                                'price': current_price, 
-                                'pnl': pnl_usdt,
-                                'pnl_pct': pnl_pct
-                            })
+                        if (
+                            current_price >= pos["entry"] * 1.02
+                            or current_price <= pos["entry"] * 0.99
+                        ):
+                            pnl_pct = (
+                                (current_price -
+                                 pos["entry"]) / pos["entry"] * 100
+                            )
+                            pnl_usdt = pnl_pct * \
+                                pos["quantity"] * pos["entry"] / 100
+                            trades.append(
+                                {
+                                    "action": "SELL",
+                                    "price": current_price,
+                                    "pnl": pnl_usdt,
+                                    "pnl_pct": pnl_pct,
+                                }
+                            )
                             balance += pnl_usdt
                             positions = []
-                            
-                    elif pos['side'] == 'SHORT':
+
+                    elif pos["side"] == "SHORT":
                         # TP: 2%, SL: 1%
-                        if current_price <= pos['entry'] * 0.98 or current_price >= pos['entry'] * 1.01:
-                            pnl_pct = (pos['entry'] - current_price) / pos['entry'] * 100
-                            pnl_usdt = pnl_pct * pos['quantity'] * pos['entry'] / 100
-                            trades.append({
-                                'action': 'BUY', 
-                                'price': current_price, 
-                                'pnl': pnl_usdt,
-                                'pnl_pct': pnl_pct
-                            })
+                        if (
+                            current_price <= pos["entry"] * 0.98
+                            or current_price >= pos["entry"] * 1.01
+                        ):
+                            pnl_pct = (
+                                (pos["entry"] - current_price) /
+                                pos["entry"] * 100
+                            )
+                            pnl_usdt = pnl_pct * \
+                                pos["quantity"] * pos["entry"] / 100
+                            trades.append(
+                                {
+                                    "action": "BUY",
+                                    "price": current_price,
+                                    "pnl": pnl_usdt,
+                                    "pnl_pct": pnl_pct,
+                                }
+                            )
                             balance += pnl_usdt
                             positions = []
-                    
+
                     # Cierre por tiempo máximo (10 velas)
-                    if i - pos['entry_idx'] > 10:
-                        current_price = df_indicators.iloc[i]['close']
-                        if pos['side'] == 'LONG':
-                            pnl_pct = (current_price - pos['entry']) / pos['entry'] * 100
+                    if i - pos["entry_idx"] > 10:
+                        current_price = df_indicators.iloc[i]["close"]
+                        if pos["side"] == "LONG":
+                            pnl_pct = (
+                                (current_price -
+                                 pos["entry"]) / pos["entry"] * 100
+                            )
                         else:
-                            pnl_pct = (pos['entry'] - current_price) / pos['entry'] * 100
-                            
-                        pnl_usdt = pnl_pct * pos['quantity'] * pos['entry'] / 100
-                        trades.append({
-                            'action': 'CLOSE_TIME', 
-                            'price': current_price, 
-                            'pnl': pnl_usdt,
-                            'pnl_pct': pnl_pct
-                        })
+                            pnl_pct = (
+                                (pos["entry"] - current_price) /
+                                pos["entry"] * 100
+                            )
+
+                        pnl_usdt = pnl_pct * \
+                            pos["quantity"] * pos["entry"] / 100
+                        trades.append(
+                            {
+                                "action": "CLOSE_TIME",
+                                "price": current_price,
+                                "pnl": pnl_usdt,
+                                "pnl_pct": pnl_pct,
+                            }
+                        )
                         balance += pnl_usdt
                         positions = []
-            
+
             # Calcular métricas (CON PROTECCIÓN CONTRA DIVISIÓN POR CERO)
-            closed_trades = [t for t in trades if 'pnl' in t]
-            
+            closed_trades = [t for t in trades if "pnl" in t]
+
             if not closed_trades:
                 return {
-                    'total_trades': 0,
-                    'win_rate': 0,
-                    'avg_win': 0,
-                    'avg_loss': 0,
-                    'profit_loss': 0,
-                    'profit_factor': 0,
-                    'max_drawdown': 0,
-                    'sharpe_ratio': 0,
-                    'final_balance': balance
+                    "total_trades": 0,
+                    "win_rate": 0,
+                    "avg_win": 0,
+                    "avg_loss": 0,
+                    "profit_loss": 0,
+                    "profit_factor": 0,
+                    "max_drawdown": 0,
+                    "sharpe_ratio": 0,
+                    "final_balance": balance,
                 }
-            
-            winning_trades = [t for t in closed_trades if t['pnl'] > 0]
-            losing_trades = [t for t in closed_trades if t['pnl'] <= 0]
-            
+
+            winning_trades = [t for t in closed_trades if t["pnl"] > 0]
+            losing_trades = [t for t in closed_trades if t["pnl"] <= 0]
+
             total_trades = len(closed_trades)
             win_rate = len(winning_trades) / max(total_trades, 1) * 100
-            
-            avg_win = np.mean([t['pnl'] for t in winning_trades]) if winning_trades else 0
-            avg_loss = np.mean([t['pnl'] for t in losing_trades]) if losing_trades else 0
-            
-            total_pnl = sum(t.get('pnl', 0) for t in closed_trades)
-            
+
+            avg_win = (
+                np.mean([t["pnl"] for t in winning_trades]
+                        ) if winning_trades else 0
+            )
+            avg_loss = (
+                np.mean([t["pnl"] for t in losing_trades]
+                        ) if losing_trades else 0
+            )
+
+            total_pnl = sum(t.get("pnl", 0) for t in closed_trades)
+
             # Calcular profit factor con protección
-            total_wins = sum(t['pnl'] for t in winning_trades) if winning_trades else 0
-            total_losses = abs(sum(t['pnl'] for t in losing_trades)) if losing_trades else 0
+            total_wins = sum(t["pnl"]
+                             for t in winning_trades) if winning_trades else 0
+            total_losses = (
+                abs(sum(t["pnl"]
+                    for t in losing_trades)) if losing_trades else 0
+            )
             profit_factor = total_wins / max(total_losses, 0.001)
-            
+
             # Calcular drawdown
             equity_curve = []
             current_equity = initial_balance
             for trade in closed_trades:
-                current_equity += trade.get('pnl', 0)
+                current_equity += trade.get("pnl", 0)
                 equity_curve.append(current_equity)
-            
+
             return {
-                'total_trades': total_trades,
-                'win_rate': win_rate,
-                'avg_win': avg_win,
-                'avg_loss': avg_loss,
-                'profit_loss': total_pnl,
-                'profit_factor': profit_factor,
-                'max_drawdown': self._calculate_max_drawdown(equity_curve),
-                'sharpe_ratio': self._calculate_sharpe_ratio([t.get('pnl', 0) for t in closed_trades]),
-                'final_balance': balance,
-                'return_pct': ((balance - initial_balance) / initial_balance) * 100
+                "total_trades": total_trades,
+                "win_rate": win_rate,
+                "avg_win": avg_win,
+                "avg_loss": avg_loss,
+                "profit_loss": total_pnl,
+                "profit_factor": profit_factor,
+                "max_drawdown": self._calculate_max_drawdown(equity_curve),
+                "sharpe_ratio": self._calculate_sharpe_ratio(
+                    [t.get("pnl", 0) for t in closed_trades]
+                ),
+                "final_balance": balance,
+                "return_pct": ((balance - initial_balance) / initial_balance) * 100,
             }
-        
+
         except Exception as e:
             log.error(f"Error en simulación de trading: {e}")
             return {"error": f"Error en simulación: {str(e)}"}
-    
+
     def _calculate_max_drawdown(self, equity_curve):
         """Calcular máxima pérdida acumulada - CORREGIDO"""
         if not equity_curve or len(equity_curve) == 0:
             return 0
-        
+
         try:
             peak = equity_curve[0]
             max_drawdown = 0
-            
+
             for equity in equity_curve:
                 if equity > peak:
                     peak = equity
                 drawdown = (peak - equity) / peak * 100
                 if drawdown > max_drawdown:
                     max_drawdown = drawdown
-            
+
             return max_drawdown
         except:
             return 0
-    
+
     def _calculate_sharpe_ratio(self, pnl_series):
         """Calcular ratio Sharpe - CORREGIDO"""
         if not pnl_series or len(pnl_series) < 2:
             return 0
-        
+
         try:
             returns = np.array(pnl_series)
             if np.std(returns) == 0:
                 return 0
-            return (np.mean(returns) / np.std(returns)) * np.sqrt(252)  # Anualizado con días trading
+            return (np.mean(returns) / np.std(returns)) * np.sqrt(
+                252
+            )  # Anualizado con días trading
         except:
             return 0
+
 
 # ═══════════════════════════════════════════════════════════════════
 # ANALYTICS AVANZADOS (CORREGIDO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class AnalyticsEngine:
     """Motor de analytics avanzado"""
-    
+
     def __init__(self):
         self.trade_history = []
         self.performance_metrics = {}
-    
+
     def record_trade(self, trade_data):
         """Registrar trade para analytics"""
-        self.trade_history.append({
-            **trade_data,
-            'timestamp': datetime.now().isoformat()
-        })
-        
+        self.trade_history.append(
+            {**trade_data, "timestamp": datetime.now().isoformat()}
+        )
+
         # Mantener sólo últimos 1000 trades
         if len(self.trade_history) > 1000:
             self.trade_history = self.trade_history[-1000:]
-    
+
     def calculate_metrics(self):
         """Calcular métricas de performance (MEJORADO)"""
         try:
             if not self.trade_history:
                 return {}
-            
+
             df = pd.DataFrame(self.trade_history)
-            if df.empty or 'pnl' not in df.columns:
+            if df.empty or "pnl" not in df.columns:
                 return {}
-                
+
             # Convertir y limpiar datos
-            df['pnl'] = pd.to_numeric(df['pnl'], errors='coerce')
-            df = df.dropna(subset=['pnl'])
-            
+            df["pnl"] = pd.to_numeric(df["pnl"], errors="coerce")
+            df = df.dropna(subset=["pnl"])
+
             if df.empty:
                 return {}
-                
+
             # Cálculos seguros
-            wins = df[df['pnl'] > 0]
-            losses = df[df['pnl'] < 0]
-            
+            wins = df[df["pnl"] > 0]
+            losses = df[df["pnl"] < 0]
+
             total_trades = len(df)
             win_rate = len(wins) / max(total_trades, 1) * 100
-            
-            avg_win = wins['pnl'].mean() if not wins.empty else 0
-            avg_loss = losses['pnl'].mean() if not losses.empty else 0
-            
-            total_wins = wins['pnl'].sum() if not wins.empty else 0
-            total_losses = abs(losses['pnl'].sum()) if not losses.empty else 0
-            
-            profit_factor = total_wins / max(total_losses, 0.001)  # Evitar división por cero
-            
+
+            avg_win = wins["pnl"].mean() if not wins.empty else 0
+            avg_loss = losses["pnl"].mean() if not losses.empty else 0
+
+            total_wins = wins["pnl"].sum() if not wins.empty else 0
+            total_losses = abs(losses["pnl"].sum()) if not losses.empty else 0
+
+            profit_factor = total_wins / max(
+                total_losses, 0.001
+            )  # Evitar división por cero
+
             return {
-                'total_trades': total_trades,
-                'win_rate': win_rate,
-                'avg_win': avg_win,
-                'avg_loss': avg_loss,
-                'profit_factor': profit_factor,
-                'max_drawdown': self._calculate_max_drawdown(df['pnl']),
-                'sharpe_ratio': self._calculate_sharpe_ratio(df['pnl']),
-                'total_pnl': df['pnl'].sum()
+                "total_trades": total_trades,
+                "win_rate": win_rate,
+                "avg_win": avg_win,
+                "avg_loss": avg_loss,
+                "profit_factor": profit_factor,
+                "max_drawdown": self._calculate_max_drawdown(df["pnl"]),
+                "sharpe_ratio": self._calculate_sharpe_ratio(df["pnl"]),
+                "total_pnl": df["pnl"].sum(),
             }
-        
+
         except Exception as e:
             log.error(f"Error calculando métricas: {e}")
             return {}
-    
+
     def _calculate_max_drawdown(self, pnl_series):
         """Calcular máxima pérdida acumulada (CORREGIDO)"""
         try:
             if pnl_series.empty:
                 return 0
-                
+
             cumulative = pnl_series.cumsum()
             running_max = cumulative.expanding().max()
-            drawdown = (cumulative - running_max)
+            drawdown = cumulative - running_max
             return drawdown.min() if not drawdown.empty else 0
         except:
             return 0
-    
+
     def _calculate_sharpe_ratio(self, pnl_series):
         """Calcular ratio Sharpe (CORREGIDO)"""
         try:
             if pnl_series.empty or len(pnl_series) < 2:
                 return 0
-                
+
             if pnl_series.std() == 0:
                 return 0
-                
+
             return (pnl_series.mean() / pnl_series.std()) * np.sqrt(365)
         except:
             return 0
+
 
 # ═══════════════════════════════════════════════════════════════════
 # ESTADO GLOBAL MEJORADO (CORREGIDO)
@@ -1277,19 +1502,19 @@ app_state = {
         "wins": 0,
         "losses": 0,
         "win_rate": 0.0,
-        "max_drawdown": 0.0
+        "max_drawdown": 0.0,
     },
     "balance": 0.0,
     "trades_history": [],
     "health_metrics": {
-        'uptime': 0,
-        'error_rate': 0,
-        'win_rate': 0,
-        'signals_per_hour': 0,
-        'metrics': health_monitor.metrics.copy()
+        "uptime": 0,
+        "error_rate": 0,
+        "win_rate": 0,
+        "signals_per_hour": 0,
+        "metrics": health_monitor.metrics.copy(),
     },  # Estado inicial seguro
     "market_condition": "NORMAL",
-    "advanced_features": True
+    "advanced_features": True,
 }
 state_lock = threading.Lock()
 bot_thread = None
@@ -1298,9 +1523,10 @@ bot_thread = None
 # CLIENTE BINANCE (CORREGIDO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class BinanceFutures:
     """Cliente para Binance Futures API con mejoras - VERSIÓN CORREGIDA"""
-    
+
     def __init__(self):
         api_key = os.getenv("BINANCE_API_KEY")
         api_secret = os.getenv("BINANCE_API_SECRET")
@@ -1312,7 +1538,7 @@ class BinanceFutures:
         self.client = Client(api_key, api_secret, testnet=testnet)
         mode = "TESTNET" if testnet else "MAINNET"
         log.info(f"🔧 Conectado a Binance Futures {mode}")
-        
+
         try:
             self.exchange_info = self.client.futures_exchange_info()
             log.info("✅ Exchange info cargada")
@@ -1322,21 +1548,21 @@ class BinanceFutures:
 
     def _safe_api_call(self, func, *args, **kwargs):
         """Llamada segura con reintentos"""
-        health_monitor.record_metric('api_calls')
+        health_monitor.record_metric("api_calls")
         for attempt in range(3):
             try:
                 time.sleep(0.5 * attempt)
                 result = func(*args, **kwargs)
                 return result
             except BinanceAPIException as e:
-                health_monitor.record_metric('errors')
+                health_monitor.record_metric("errors")
                 if e.code in [-4131, -1122, -2011, -1013]:
                     log.warning(f"⚠️ Error API {e.code}: {e.message}")
                     return None
                 if attempt == 2:
                     log.error(f"❌ Error final: {e.message}")
             except Exception as e:
-                health_monitor.record_metric('errors')
+                health_monitor.record_metric("errors")
                 if attempt == 2:
                     log.error(f"❌ Error: {e}")
         return None
@@ -1347,7 +1573,7 @@ class BinanceFutures:
             self._safe_api_call(
                 self.client.futures_change_leverage,
                 symbol=symbol,
-                leverage=config.LEVERAGE
+                leverage=config.LEVERAGE,
             )
             log.info(f"✅ Leverage {config.LEVERAGE}x para {symbol}")
         except Exception as e:
@@ -1356,17 +1582,22 @@ class BinanceFutures:
     def get_symbol_filters(self, symbol: str) -> Optional[Dict]:
         """Obtener filtros del símbolo"""
         try:
-            s_info = next((s for s in self.exchange_info['symbols'] 
-                          if s['symbol'] == symbol), None)
+            s_info = next(
+                (s for s in self.exchange_info["symbols"]
+                 if s["symbol"] == symbol),
+                None,
+            )
             if not s_info:
                 return None
-                
-            filters = {f['filterType']: f for f in s_info['filters']}
+
+            filters = {f["filterType"]: f for f in s_info["filters"]}
             return {
-                "stepSize": float(filters['LOT_SIZE']['stepSize']),
-                "minQty": float(filters['LOT_SIZE']['minQty']),
-                "tickSize": float(filters['PRICE_FILTER']['tickSize']),
-                "minNotional": float(filters.get('MIN_NOTIONAL', {}).get('notional', 5.0))
+                "stepSize": float(filters["LOT_SIZE"]["stepSize"]),
+                "minQty": float(filters["LOT_SIZE"]["minQty"]),
+                "tickSize": float(filters["PRICE_FILTER"]["tickSize"]),
+                "minNotional": float(
+                    filters.get("MIN_NOTIONAL", {}).get("notional", 5.0)
+                ),
             }
         except Exception as e:
             log.error(f"Error obteniendo filtros {symbol}: {e}")
@@ -1376,14 +1607,14 @@ class BinanceFutures:
         """Colocar orden de mercado - CORREGIDO"""
         if config.DRY_RUN:
             log.info(f"[DRY_RUN] Orden: {side} {quantity} {symbol}")
-            return {'mock': True, 'orderId': int(time.time() * 1000)}
+            return {"mock": True, "orderId": int(time.time() * 1000)}
 
         return self._safe_api_call(
             self.client.futures_create_order,
             symbol=symbol,
             side=side,
             type=FUTURE_ORDER_TYPE_MARKET,
-            quantity=quantity
+            quantity=quantity,
         )
 
     def close_position(self, symbol: str, position_amt: float) -> Optional[Dict]:
@@ -1399,13 +1630,15 @@ class BinanceFutures:
         precision = max(0, int(round(-math.log10(step))))
         return round(math.floor(value / step) * step, precision)
 
+
 # ═══════════════════════════════════════════════════════════════════
 # GESTOR DE CAPITAL MEJORADO (CORREGIDO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 class CapitalManager:
     """Gestor de capital mejorado - VERSIÓN CORREGIDA"""
-    
+
     def __init__(self, api):
         self.api = api
         self.current_balance = 0.0
@@ -1420,9 +1653,9 @@ class CapitalManager:
         try:
             account = self.api._safe_api_call(self.api.client.futures_account)
             if account:
-                for asset in account.get('assets', []):
-                    if asset.get('asset') == 'USDT':
-                        return float(asset.get('walletBalance', 0))
+                for asset in account.get("assets", []):
+                    if asset.get("asset") == "USDT":
+                        return float(asset.get("walletBalance", 0))
             return 0.0
         except Exception as e:
             log.error(f"Error obteniendo balance: {e}")
@@ -1441,7 +1674,7 @@ class CapitalManager:
                 if time.time() - self.last_reset > 86400:  # 24 horas
                     self.daily_pnl = 0
                     self.last_reset = time.time()
-                
+
                 self.current_balance = new_balance
                 self.peak_balance = max(self.peak_balance, new_balance)
                 self.last_update = time.time()
@@ -1457,30 +1690,36 @@ class CapitalManager:
         """Calcular drawdown actual"""
         if self.initial_balance == 0:
             return 0.0
-        return ((self.initial_balance - self.current_balance) / self.initial_balance) * 100
+        return (
+            (self.initial_balance - self.current_balance) / self.initial_balance
+        ) * 100
 
     def _update_drawdown_state(self):
         if self.peak_balance <= 0:
             return
 
-        current_drawdown = ((self.peak_balance - self.current_balance) / self.peak_balance) * 100
+        current_drawdown = (
+            (self.peak_balance - self.current_balance) / self.peak_balance
+        ) * 100
         stats = app_state.get("performance_stats", {})
         max_drawdown = stats.get("max_drawdown", 0.0)
         stats["max_drawdown"] = max(max_drawdown, current_drawdown)
         app_state["performance_stats"] = stats
 
+
 # ═══════════════════════════════════════════════════════════════════
 # NOTIFICADOR TELEGRAM MEJORADO
 # ═══════════════════════════════════════════════════════════════════
 
+
 class TelegramNotifier:
     """Notificaciones Telegram mejoradas"""
-    
+
     def __init__(self):
         self.token = os.getenv("TELEGRAM_BOT_TOKEN")
         self.chat_id = os.getenv("TELEGRAM_CHAT_ID")
         self.enabled = bool(self.token and self.chat_id)
-        
+
         if self.enabled:
             log.info(f"✅ Telegram configurado")
 
@@ -1488,14 +1727,15 @@ class TelegramNotifier:
         """Enviar mensaje"""
         if not self.enabled:
             return False
-        
+
         try:
             url = f"https://api.telegram.org/bot{self.token}/sendMessage"
-            requests.post(url, json={
-                "chat_id": self.chat_id,
-                "text": message,
-                "parse_mode": "HTML"
-            }, timeout=10)
+            requests.post(
+                url,
+                json={"chat_id": self.chat_id,
+                      "text": message, "parse_mode": "HTML"},
+                timeout=10,
+            )
             return True
         except:
             return False
@@ -1529,152 +1769,157 @@ class TelegramNotifier:
         msg = f"🚨 <b>ALERTA DEL SISTEMA</b>\n\n{message}"
         return self.send_message(msg)
 
+
 # ═══════════════════════════════════════════════════════════════════
 # DETECTOR DE SEÑALES
 # ═══════════════════════════════════════════════════════════════════
 
+
 class SignalDetector:
     """Detector de señales con multi-confirmación"""
-    
+
     @staticmethod
     def calculate_indicators(df: pd.DataFrame) -> pd.DataFrame:
         """Calcular indicadores"""
         try:
             # EMAs
-            df['ema_8'] = df['close'].ewm(span=8, adjust=False).mean()
-            df['ema_21'] = df['close'].ewm(span=21, adjust=False).mean()
-            df['ema_50'] = df['close'].ewm(span=50, adjust=False).mean()
-            
+            df["ema_8"] = df["close"].ewm(span=8, adjust=False).mean()
+            df["ema_21"] = df["close"].ewm(span=21, adjust=False).mean()
+            df["ema_50"] = df["close"].ewm(span=50, adjust=False).mean()
+
             # RSI
-            delta = df['close'].diff()
+            delta = df["close"].diff()
             gain = delta.where(delta > 0, 0).ewm(span=14, adjust=False).mean()
             loss = -delta.where(delta < 0, 0).ewm(span=14, adjust=False).mean()
             rs = gain / loss.replace(0, np.nan)
-            df['rsi'] = 100 - (100 / (1 + rs))
-            
+            df["rsi"] = 100 - (100 / (1 + rs))
+
             # MACD
-            exp1 = df['close'].ewm(span=12, adjust=False).mean()
-            exp2 = df['close'].ewm(span=26, adjust=False).mean()
-            df['macd'] = exp1 - exp2
-            df['macd_signal'] = df['macd'].ewm(span=9, adjust=False).mean()
-            df['macd_hist'] = df['macd'] - df['macd_signal']
-            
+            exp1 = df["close"].ewm(span=12, adjust=False).mean()
+            exp2 = df["close"].ewm(span=26, adjust=False).mean()
+            df["macd"] = exp1 - exp2
+            df["macd_signal"] = df["macd"].ewm(span=9, adjust=False).mean()
+            df["macd_hist"] = df["macd"] - df["macd_signal"]
+
             # ATR
-            high_low = df['high'] - df['low']
-            high_close = np.abs(df['high'] - df['close'].shift())
-            low_close = np.abs(df['low'] - df['close'].shift())
+            high_low = df["high"] - df["low"]
+            high_close = np.abs(df["high"] - df["close"].shift())
+            low_close = np.abs(df["low"] - df["close"].shift())
             ranges = pd.concat([high_low, high_close, low_close], axis=1)
             true_range = ranges.max(axis=1)
-            df['atr'] = true_range.rolling(14).mean()
-            
+            df["atr"] = true_range.rolling(14).mean()
+
             # Volumen
-            df['volume_ma'] = df['volume'].rolling(20).mean()
-            df['volume_ratio'] = df['volume'] / df['volume_ma'].replace(0, np.nan)
-            
+            df["volume_ma"] = df["volume"].rolling(20).mean()
+            df["volume_ratio"] = df["volume"] / \
+                df["volume_ma"].replace(0, np.nan)
+
             # Momentum
-            df['momentum'] = df['close'] - df['close'].shift(10)
-            
+            df["momentum"] = df["close"] - df["close"].shift(10)
+
             return df
         except Exception as e:
             log.error(f"Error calculando indicadores: {e}")
             return df
-    
+
     @staticmethod
     def detect_signal(df: pd.DataFrame, symbol: str) -> Optional[Dict]:
         """Detectar señal de trading"""
-        
+
         if len(df) < 50:
             return None
-        
+
         last = df.iloc[-1]
         prev = df.iloc[-2]
-        
+
         # Verificar datos válidos
-        required = ['close', 'ema_8', 'ema_21', 'rsi', 'macd', 'atr']
+        required = ["close", "ema_8", "ema_21", "rsi", "macd", "atr"]
         if any(pd.isna(last[field]) for field in required):
             return None
-        
+
         # LONG
         long_score = 0
         long_reasons = []
-        
-        if last['ema_8'] > last['ema_21'] and prev['ema_8'] <= prev['ema_21']:
+
+        if last["ema_8"] > last["ema_21"] and prev["ema_8"] <= prev["ema_21"]:
             long_score += 2
             long_reasons.append("✓ Cruce EMA Alcista")
-        if last['close'] > last['ema_50']:
+        if last["close"] > last["ema_50"]:
             long_score += 1
             long_reasons.append("✓ Tendencia Alcista")
-        if 30 < last['rsi'] < 68:
+        if 30 < last["rsi"] < 68:
             long_score += 1
             long_reasons.append(f"✓ RSI {last['rsi']:.1f}")
-        if last['macd'] > last['macd_signal']:
+        if last["macd"] > last["macd_signal"]:
             long_score += 1
             long_reasons.append("✓ MACD Alcista")
-        if last['macd_hist'] > prev['macd_hist']:
+        if last["macd_hist"] > prev["macd_hist"]:
             long_score += 1
             long_reasons.append("✓ MACD Momentum")
-        if last['volume_ratio'] > 1.1:
+        if last["volume_ratio"] > 1.1:
             long_score += 1
             long_reasons.append("✓ Volumen Alto")
-        if last['momentum'] > 0:
+        if last["momentum"] > 0:
             long_score += 1
             long_reasons.append("✓ Momentum+")
-        
+
         # SHORT
         short_score = 0
         short_reasons = []
-        
-        if last['ema_8'] < last['ema_21'] and prev['ema_8'] >= prev['ema_21']:
+
+        if last["ema_8"] < last["ema_21"] and prev["ema_8"] >= prev["ema_21"]:
             short_score += 2
             short_reasons.append("✓ Cruce EMA Bajista")
-        if last['close'] < last['ema_50']:
+        if last["close"] < last["ema_50"]:
             short_score += 1
             short_reasons.append("✓ Tendencia Bajista")
-        if 32 < last['rsi'] < 70:
+        if 32 < last["rsi"] < 70:
             short_score += 1
             short_reasons.append(f"✓ RSI {last['rsi']:.1f}")
-        if last['macd'] < last['macd_signal']:
+        if last["macd"] < last["macd_signal"]:
             short_score += 1
             short_reasons.append("✓ MACD Bajista")
-        if last['macd_hist'] < prev['macd_hist']:
+        if last["macd_hist"] < prev["macd_hist"]:
             short_score += 1
             short_reasons.append("✓ MACD Momentum")
-        if last['volume_ratio'] > 1.1:
+        if last["volume_ratio"] > 1.1:
             short_score += 1
             short_reasons.append("✓ Volumen Alto")
-        if last['momentum'] < 0:
+        if last["momentum"] < 0:
             short_score += 1
             short_reasons.append("✓ Momentum-")
-        
+
         # Decidir
         if long_score >= config.MIN_SIGNAL_SCORE:
-            health_monitor.record_metric('signals_detected')
+            health_monitor.record_metric("signals_detected")
             return {
-                'type': 'LONG',
-                'strength': min(long_score / 8, 0.95),
-                'reasons': long_reasons,
-                'price': last['close'],
-                'atr': last['atr'],
-                'rsi': last['rsi'],
-                'score': long_score
+                "type": "LONG",
+                "strength": min(long_score / 8, 0.95),
+                "reasons": long_reasons,
+                "price": last["close"],
+                "atr": last["atr"],
+                "rsi": last["rsi"],
+                "score": long_score,
             }
         elif short_score >= config.MIN_SIGNAL_SCORE:
-            health_monitor.record_metric('signals_detected')
+            health_monitor.record_metric("signals_detected")
             return {
-                'type': 'SHORT',
-                'strength': min(short_score / 8, 0.95),
-                'reasons': short_reasons,
-                'price': last['close'],
-                'atr': last['atr'],
-                'rsi': last['rsi'],
-                'score': short_score
+                "type": "SHORT",
+                "strength": min(short_score / 8, 0.95),
+                "reasons": short_reasons,
+                "price": last["close"],
+                "atr": last["atr"],
+                "rsi": last["rsi"],
+                "score": short_score,
             }
-        
+
         return None
+
 
 # ═══════════════════════════════════════════════════════════════════
 # GESTOR DE RIESGO MEJORADO
 # ═══════════════════════════════════════════════════════════════════
+
 
 class RiskManager:
     """Gestor de riesgo dinámico mejorado"""
@@ -1682,9 +1927,9 @@ class RiskManager:
     @staticmethod
     def calculate_sl_tp(signal: Dict, price: float) -> Tuple[float, float]:
         """Calcular SL y TP dinámicos"""
-        atr = signal.get('atr', price * 0.01)
-        strength = signal.get('strength', 0.5)
-        
+        atr = signal.get("atr", price * 0.01)
+        strength = signal.get("strength", 0.5)
+
         # Ajustar según condiciones de mercado
         market_condition = app_state.get("market_condition", "NORMAL")
         if market_condition == "HIGH_VOLATILITY":
@@ -1696,11 +1941,11 @@ class RiskManager:
         else:
             sl_mult = 1.8 - (strength * 0.6)
             tp_mult = 2.2 + (strength * 1.3)
-        
+
         sl_dist = atr * sl_mult
         tp_dist = atr * tp_mult
-        
-        if signal['type'] == "LONG":
+
+        if signal["type"] == "LONG":
             return price - sl_dist, price + tp_dist
         else:
             return price + sl_dist, price - tp_dist
@@ -1713,11 +1958,7 @@ class ImprovedRiskManager:
         self.config = config
 
     def calculate_position_size_kelly(
-        self,
-        balance: float,
-        signal_strength: float,
-        win_rate: float,
-        avg_rr: float
+        self, balance: float, signal_strength: float, win_rate: float, avg_rr: float
     ) -> float:
         base_risk = balance * (self.config.RISK_PER_TRADE_PERCENT / 100)
         if win_rate <= 0 or avg_rr <= 0:
@@ -1728,101 +1969,113 @@ class ImprovedRiskManager:
         adjusted_fraction = min(kelly_fraction * max(signal_strength, 0), 1.0)
         return max(base_risk, balance * adjusted_fraction)
 
-    def calculate_sl_tp_levels(self, signal: Dict[str, float], price: float) -> Dict[str, float]:
-        atr = signal.get('atr', price * 0.01)
-        strength = signal.get('strength', 0.5)
+    def calculate_sl_tp_levels(
+        self, signal: Dict[str, float], price: float
+    ) -> Dict[str, float]:
+        atr = signal.get("atr", price * 0.01)
+        strength = signal.get("strength", 0.5)
 
         base_sl_mult = 2.0
         reward_steps = [1.8, 2.6, 3.4]
         reward_boost = strength * 0.5
 
-        if signal.get('type') == 'LONG':
+        if signal.get("type") == "LONG":
             sl = price - atr * base_sl_mult
-            tps = [price + atr * (step + reward_boost) for step in reward_steps]
+            tps = [price + atr * (step + reward_boost)
+                   for step in reward_steps]
         else:
             sl = price + atr * base_sl_mult
-            tps = [price - atr * (step + reward_boost) for step in reward_steps]
+            tps = [price - atr * (step + reward_boost)
+                   for step in reward_steps]
 
-        return {
-            'sl': sl,
-            'tp1': tps[0],
-            'tp2': tps[1],
-            'tp3': tps[2]
-        }
+        return {"sl": sl, "tp1": tps[0], "tp2": tps[1], "tp3": tps[2]}
 
 
 # ═══════════════════════════════════════════════════════════════════
 # TRAILING STOP MEJORADO
 # ═══════════════════════════════════════════════════════════════════
 
+
 class TrailingStop:
     """Trailing stop automático mejorado"""
-    
+
     def __init__(self):
         self.data = {}
-    
-    def update(self, symbol: str, price: float, side: str, entry: float) -> Optional[Dict]:
+
+    def update(
+        self, symbol: str, price: float, side: str, entry: float
+    ) -> Optional[Dict]:
         """Actualizar trailing stop mejorado"""
-        
+
         # Calcular PnL%
         if side == "LONG":
             pnl_pct = ((price - entry) / entry) * 100
         else:
             pnl_pct = ((entry - price) / entry) * 100
-        
+
         # Activar solo con ganancia
         if pnl_pct < config.TRAILING_STOP_ACTIVATION:
             return None
-        
+
         # Inicializar
         if symbol not in self.data:
-            self.data[symbol] = {'max_price': price, 'max_pnl': pnl_pct}
+            self.data[symbol] = {"max_price": price, "max_pnl": pnl_pct}
             log.info(f"🎯 Trailing Stop ACTIVADO: {symbol} @ {pnl_pct:.2f}%")
-        
+
         data = self.data[symbol]
-        
+
         # Actualizar máximo
         if side == "LONG":
-            if price > data['max_price']:
-                data['max_price'] = price
-                data['max_pnl'] = pnl_pct
-            
+            if price > data["max_price"]:
+                data["max_price"] = price
+                data["max_pnl"] = pnl_pct
+
             # Trailing stop adaptativo
             current_trailing = config.TRAILING_STOP_DISTANCE
             if pnl_pct > 2.0:  # Reducir trailing en ganancias altas
-                current_trailing = max(0.1, config.TRAILING_STOP_DISTANCE * 0.7)
-                
-            stop = data['max_price'] * (1 - current_trailing / 100)
+                current_trailing = max(
+                    0.1, config.TRAILING_STOP_DISTANCE * 0.7)
+
+            stop = data["max_price"] * (1 - current_trailing / 100)
             if price <= stop:
-                return {'should_close': True, 'reason': 'Trailing Stop', 
-                       'max_pnl': data['max_pnl']}
+                return {
+                    "should_close": True,
+                    "reason": "Trailing Stop",
+                    "max_pnl": data["max_pnl"],
+                }
         else:
-            if price < data['max_price']:
-                data['max_price'] = price
-                data['max_pnl'] = pnl_pct
-            
+            if price < data["max_price"]:
+                data["max_price"] = price
+                data["max_pnl"] = pnl_pct
+
             current_trailing = config.TRAILING_STOP_DISTANCE
             if pnl_pct > 2.0:
-                current_trailing = max(0.1, config.TRAILING_STOP_DISTANCE * 0.7)
-                
-            stop = data['max_price'] * (1 + current_trailing / 100)
+                current_trailing = max(
+                    0.1, config.TRAILING_STOP_DISTANCE * 0.7)
+
+            stop = data["max_price"] * (1 + current_trailing / 100)
             if price >= stop:
-                return {'should_close': True, 'reason': 'Trailing Stop',
-                       'max_pnl': data['max_pnl']}
-        
+                return {
+                    "should_close": True,
+                    "reason": "Trailing Stop",
+                    "max_pnl": data["max_pnl"],
+                }
+
         return None
-    
+
     def clear(self, symbol: str):
         """Limpiar datos"""
         self.data.pop(symbol, None)
+
 
 # ═══════════════════════════════════════════════════════════════════
 # GESTOR DE POSICIONES AVANZADO
 # ═══════════════════════════════════════════════════════════════════
 
+
 class AdvancedPositionManager:
     """Gestor de posiciones avanzado con pyramiding"""
-    
+
     def __init__(self, api, capital_mgr):
         self.api = api
         self.capital = capital_mgr
@@ -1841,25 +2094,25 @@ class AdvancedPositionManager:
         """Verificar si se puede añadir a posición existente"""
         if symbol not in self.positions:
             return False
-        
+
         pos = self.positions[symbol]
-        current_price = signal['price']
-        
+        current_price = signal["price"]
+
         # Verificar dirección y condiciones para añadir
-        if pos['side'] != signal['type']:
+        if pos["side"] != signal["type"]:
             return False
-        
+
         # Verificar niveles de pyramiding
         current_levels = self.entry_levels.get(symbol, 0)
         if current_levels >= config.MAX_PYRAMID_LEVELS:
             return False
-        
+
         # Lógica de pyramiding (añadir en retrocesos)
-        if pos['side'] == 'LONG' and current_price < pos['entry'] * 0.99:
+        if pos["side"] == "LONG" and current_price < pos["entry"] * 0.99:
             return True
-        elif pos['side'] == 'SHORT' and current_price > pos['entry'] * 1.01:
+        elif pos["side"] == "SHORT" and current_price > pos["entry"] * 1.01:
             return True
-        
+
         return False
 
     def add_to_position(self, symbol, signal):
@@ -1867,112 +2120,125 @@ class AdvancedPositionManager:
         try:
             if not config.ENABLE_PYRAMIDING:
                 return False
-                
+
             current_pos = self.positions[symbol]
-            new_quantity = self._calculate_size(symbol, signal['price'], signal) * 0.5  # 50% tamaño inicial
-            
+            new_quantity = (
+                self._calculate_size(symbol, signal["price"], signal) * 0.5
+            )  # 50% tamaño inicial
+
             if new_quantity <= 0:
                 return False
-            
+
             # Ejecutar orden adicional
-            order_side = SIDE_BUY if current_pos['side'] == "LONG" else SIDE_SELL
+            order_side = SIDE_BUY if current_pos["side"] == "LONG" else SIDE_SELL
             order = self.api.place_order(symbol, order_side, new_quantity)
-            
+
             if order:
                 # Actualizar posición promedio
-                total_qty = current_pos['qty'] + new_quantity
-                current_pos['entry'] = (
-                    (current_pos['entry'] * current_pos['qty'] + signal['price'] * new_quantity) / total_qty
-                )
-                current_pos['qty'] = total_qty
-                
+                total_qty = current_pos["qty"] + new_quantity
+                current_pos["entry"] = (
+                    current_pos["entry"] * current_pos["qty"]
+                    + signal["price"] * new_quantity
+                ) / total_qty
+                current_pos["qty"] = total_qty
+
                 # Actualizar niveles de pyramiding
-                self.entry_levels[symbol] = self.entry_levels.get(symbol, 0) + 1
-                
-                log.info(f"📈 Pyramiding: Añadido a {symbol} - Nuevo promedio: {current_pos['entry']:.6f}")
+                self.entry_levels[symbol] = self.entry_levels.get(
+                    symbol, 0) + 1
+
+                log.info(
+                    f"📈 Pyramiding: Añadido a {symbol} - Nuevo promedio: {current_pos['entry']:.6f}"
+                )
                 return True
-                
+
         except Exception as e:
             log.error(f"Error en pyramiding {symbol}: {e}")
-        
+
         return False
 
     def open_position(self, symbol: str, signal: Dict) -> bool:
         """Abrir posición"""
         try:
-            price = signal['price']
-            side = signal['type']
-            
+            price = signal["price"]
+            side = signal["type"]
+
             # Verificar pyramiding primero
             if self.can_add_to_position(symbol, signal):
                 return self.add_to_position(symbol, signal)
-            
+
             # Calcular tamaño
             quantity = self._calculate_size(symbol, price, signal)
             if quantity <= 0:
                 return False
-            
+
             # Configurar símbolo
             self.api.ensure_symbol_settings(symbol)
-            
+
             # Calcular SL/TP
             sl, tp = RiskManager.calculate_sl_tp(signal, price)
-            
+
             # Abrir
             order_side = SIDE_BUY if side == "LONG" else SIDE_SELL
             order = self.api.place_order(symbol, order_side, quantity)
-            
+
             if not order:
                 return False
-            
+
             # Guardar datos
             self.positions[symbol] = {
-                'entry': price,
-                'sl': sl,
-                'tp': tp,
-                'side': side,
-                'qty': quantity,
-                'time': time.time(),
-                'signal_score': signal.get('score', 0)  # Guardar score para análisis
+                "entry": price,
+                "sl": sl,
+                "tp": tp,
+                "side": side,
+                "qty": quantity,
+                "time": time.time(),
+                # Guardar score para análisis
+                "signal_score": signal.get("score", 0),
             }
-            
+
             # Inicializar pyramiding
             self.entry_levels[symbol] = 0
-            
+
             # Registrar métricas
-            health_monitor.record_metric('positions_opened')
-            
+            health_monitor.record_metric("positions_opened")
+
             # Log
             log.info(f"")
-            log.info(f"{'='*60}")
+            log.info(f"{'=' * 60}")
             log.info(f"🚀 POSICIÓN ABIERTA: {symbol} {side}")
-            log.info(f"{'='*60}")
+            log.info(f"{'=' * 60}")
             log.info(f"💰 Precio: {price:.6f}")
             log.info(f"📦 Cantidad: {quantity:.6f}")
             log.info(f"🛡️ SL: {sl:.6f} | 🎯 TP: {tp:.6f}")
-            log.info(f"⚡ Fuerza: {signal['strength']:.0%} ({signal['score']}/8)")
-            for reason in signal['reasons']:
+            log.info(
+                f"⚡ Fuerza: {signal['strength']:.0%} ({signal['score']}/8)")
+            for reason in signal["reasons"]:
                 log.info(f"   {reason}")
-            log.info(f"{'='*60}")
-            
+            log.info(f"{'=' * 60}")
+
             # Notificar
             if self.telegram.enabled:
                 self.telegram.notify_trade_opened(
-                    symbol, side, quantity, price, self.capital.current_balance, signal['score']
+                    symbol,
+                    side,
+                    quantity,
+                    price,
+                    self.capital.current_balance,
+                    signal["score"],
                 )
-            
+
             return True
-            
+
         except Exception as e:
             log.error(f"❌ Error abriendo {symbol}: {e}")
             return False
-    
+
     def _calculate_size(self, symbol: str, price: float, signal: Dict) -> float:
         """Calcular tamaño de posición con ajuste dinámico"""
         balance = self.capital.current_balance
         if balance < config.MIN_BALANCE_THRESHOLD:
             return 0
-        
+
         # Ajuste de riesgo según condiciones
         base_risk = config.RISK_PER_TRADE_PERCENT
         if config.AUTO_RISK_ADJUSTMENT:
@@ -1981,125 +2247,131 @@ class AdvancedPositionManager:
                 base_risk *= 0.7  # Reducir riesgo en alta volatilidad
             elif market_condition == "LOW_VOLATILITY":
                 base_risk = min(3.0, base_risk * 1.1)  # Aumentar ligeramente
-        
-        strength = signal.get('strength', 0.5)
+
+        strength = signal.get("strength", 0.5)
         risk_pct = base_risk * (0.75 + strength * 0.5)
         risk_amt = balance * (risk_pct / 100)
-        
-        atr = signal.get('atr', price * 0.01)
+
+        atr = signal.get("atr", price * 0.01)
         sl_dist = atr * 1.8
-        
+
         pos_value = risk_amt / (sl_dist / price)
         quantity = pos_value / price
-        
+
         # Aplicar filtros
         filters = self.api.get_symbol_filters(symbol)
         if filters:
-            quantity = self.api.round_value(quantity, filters['stepSize'])
-            quantity = max(quantity, filters['minQty'])
-            
+            quantity = self.api.round_value(quantity, filters["stepSize"])
+            quantity = max(quantity, filters["minQty"])
+
             notional = quantity * price
-            if notional < filters['minNotional']:
-                quantity = (filters['minNotional'] / price) * 1.05
-                quantity = self.api.round_value(quantity, filters['stepSize'])
-        
+            if notional < filters["minNotional"]:
+                quantity = (filters["minNotional"] / price) * 1.05
+                quantity = self.api.round_value(quantity, filters["stepSize"])
+
         return quantity
-    
+
     def monitor_position(self, symbol: str, position: Dict) -> Optional[Dict]:
         """Monitorear posición"""
         if symbol not in self.positions:
             return None
-        
+
         pos = self.positions[symbol]
-        price = float(position.get('markPrice', 0))
-        
+        price = float(position.get("markPrice", 0))
+
         if price <= 0:
             return None
-        
+
         # SL/TP
-        if pos['side'] == "LONG":
-            if price <= pos['sl']:
-                return {'should_close': True, 'reason': 'Stop Loss'}
-            if price >= pos['tp']:
-                return {'should_close': True, 'reason': 'Take Profit'}
+        if pos["side"] == "LONG":
+            if price <= pos["sl"]:
+                return {"should_close": True, "reason": "Stop Loss"}
+            if price >= pos["tp"]:
+                return {"should_close": True, "reason": "Take Profit"}
         else:
-            if price >= pos['sl']:
-                return {'should_close': True, 'reason': 'Stop Loss'}
-            if price <= pos['tp']:
-                return {'should_close': True, 'reason': 'Take Profit'}
-        
+            if price >= pos["sl"]:
+                return {"should_close": True, "reason": "Stop Loss"}
+            if price <= pos["tp"]:
+                return {"should_close": True, "reason": "Take Profit"}
+
         # Trailing Stop
         if config.TRAILING_STOP_ENABLED:
-            result = self.trailing.update(symbol, price, pos['side'], pos['entry'])
-            if result and result.get('should_close'):
+            result = self.trailing.update(
+                symbol, price, pos["side"], pos["entry"])
+            if result and result.get("should_close"):
                 return result
-        
+
         # Tiempo máximo (30 min)
-        if time.time() - pos['time'] > 1800:
-            return {'should_close': True, 'reason': 'Max Time'}
-        
+        if time.time() - pos["time"] > 1800:
+            return {"should_close": True, "reason": "Max Time"}
+
         return None
-    
+
     def close_position(self, symbol: str, position: Dict, close_info: Dict):
         """Cerrar posición con análisis mejorado"""
         try:
             pos = self.positions.get(symbol)
             if not pos:
                 return
-            
-            pnl = float(position.get('unRealizedProfit', 0))
-            price = float(position.get('markPrice', 0))
-            
+
+            pnl = float(position.get("unRealizedProfit", 0))
+            price = float(position.get("markPrice", 0))
+
             # Cerrar
-            result = self.api.close_position(symbol, float(position['positionAmt']))
-            
+            result = self.api.close_position(
+                symbol, float(position["positionAmt"]))
+
             if result:
                 # Registrar métricas
-                health_monitor.record_metric('positions_closed')
+                health_monitor.record_metric("positions_closed")
                 if pnl > 0:
-                    health_monitor.record_metric('trades_won')
+                    health_monitor.record_metric("trades_won")
                 else:
-                    health_monitor.record_metric('trades_lost')
-                
+                    health_monitor.record_metric("trades_lost")
+
                 # Registrar en analytics
-                self.analytics.record_trade({
-                    'symbol': symbol,
-                    'side': pos['side'],
-                    'entry_price': pos['entry'],
-                    'exit_price': price,
-                    'quantity': pos['qty'],
-                    'pnl': pnl,
-                    'reason': close_info.get('reason', 'Unknown'),
-                    'duration': time.time() - pos['time']
-                })
-                
+                self.analytics.record_trade(
+                    {
+                        "symbol": symbol,
+                        "side": pos["side"],
+                        "entry_price": pos["entry"],
+                        "exit_price": price,
+                        "quantity": pos["qty"],
+                        "pnl": pnl,
+                        "reason": close_info.get("reason", "Unknown"),
+                        "duration": time.time() - pos["time"],
+                    }
+                )
+
                 # REGISTRO MEJORADO CON ANÁLISIS AVANZADO
-                if self.bot and hasattr(self.bot, 'position_monitor'):
-                    signal_score = pos.get('signal_score', 0)
+                if self.bot and hasattr(self.bot, "position_monitor"):
+                    signal_score = pos.get("signal_score", 0)
                     self.bot.position_monitor.log_position_close(
                         symbol, pos, close_info, signal_score
                     )
-                
+
                 log.info(f"")
-                log.info(f"{'='*60}")
+                log.info(f"{'=' * 60}")
                 log.info(f"🔴 POSICIÓN CERRADA: {symbol}")
-                log.info(f"{'='*60}")
+                log.info(f"{'=' * 60}")
                 log.info(f"📋 Razón: {close_info['reason']}")
                 log.info(f"💰 Entrada: {pos['entry']:.6f}")
                 log.info(f"💰 Salida: {price:.6f}")
                 log.info(f"💵 P&L: {pnl:+.2f} USDT")
-                if 'max_pnl' in close_info:
+                if "max_pnl" in close_info:
                     log.info(f"🎯 Máximo: {close_info['max_pnl']:+.2f}%")
-                log.info(f"{'='*60}")
-                
+                log.info(f"{'=' * 60}")
+
                 # Notificar
                 if self.telegram.enabled:
                     self.telegram.notify_trade_closed(
-                        symbol, pnl, close_info['reason'], 
+                        symbol,
+                        pnl,
+                        close_info["reason"],
                         self.capital.current_balance,
-                        close_info.get('max_pnl')
+                        close_info.get("max_pnl"),
                     )
-                
+
                 # Actualizar estado global
                 with state_lock:
                     app_state["performance_stats"]["realized_pnl"] += pnl
@@ -2108,29 +2380,32 @@ class AdvancedPositionManager:
                         app_state["performance_stats"]["wins"] += 1
                     else:
                         app_state["performance_stats"]["losses"] += 1
-                    
+
                     total_trades = app_state["performance_stats"]["trades_count"]
                     if total_trades > 0:
                         app_state["performance_stats"]["win_rate"] = (
-                            app_state["performance_stats"]["wins"] / total_trades * 100
+                            app_state["performance_stats"]["wins"] /
+                            total_trades * 100
                         )
-                
+
                 # Limpiar
                 self.positions.pop(symbol, None)
                 self.entry_levels.pop(symbol, None)
                 self.trailing.clear(symbol)
                 self.capital.update_balance(force=True)
-        
+
         except Exception as e:
             log.error(f"❌ Error cerrando {symbol}: {e}")
+
 
 # ═══════════════════════════════════════════════════════════════════
 # BOT PRINCIPAL MEJORADO
 # ═══════════════════════════════════════════════════════════════════
 
+
 class EnhancedTradingBot:
     """Bot de trading principal mejorado"""
-    
+
     def __init__(self):
         self.api = BinanceFutures()
         self.capital = CapitalManager(self.api)
@@ -2139,43 +2414,48 @@ class EnhancedTradingBot:
         self.telegram = TelegramNotifier()
         self.error_handler = AdvancedErrorHandler()
         self.backtester = Backtester(self.api)
-        
+
         # Nuevos sistemas
         self.position_monitor = EnhancedPositionMonitor(self.api, self.capital)
         self.trade_logger = AdvancedTradeLogger()
         self.trading_ai = TradingAI()
-        
+
         # Establecer referencias
         self.position_mgr.set_bot_reference(self)
-        
+
         self.cycle = 0
         self.start_time = time.time()
         self.scanned = {}
         self.symbols = list(config.PRIORITY_SYMBOLS)
-        
+
         self.market_volatility = 0
         self.trend_direction = 0
-    
+
     def run(self):
         """Bucle principal mejorado"""
-        
+
         log.info("")
-        log.info("="*70)
+        log.info("=" * 70)
         log.info("🚀 BOT DE TRADING MEJORADO V14.0 - SISTEMA AVANZADO CON IA")
-        log.info("="*70)
+        log.info("=" * 70)
         log.info(f"⚡ Leverage: {config.LEVERAGE}x")
-        log.info(f"📊 Estrategia: Multi-Confirmación ({config.MIN_SIGNAL_SCORE}/8)")
+        log.info(
+            f"📊 Estrategia: Multi-Confirmación ({config.MIN_SIGNAL_SCORE}/8)")
         log.info(f"🔄 Trailing Stop: {config.TRAILING_STOP_ACTIVATION}%")
-        log.info(f"📈 Pyramiding: {'Activado' if config.ENABLE_PYRAMIDING else 'Desactivado'}")
-        log.info(f"🤖 IA Analytics: {'Activado' if config.ENABLE_AI_ANALYSIS else 'Desactivado'}")
-        log.info("="*70)
+        log.info(
+            f"📈 Pyramiding: {'Activado' if config.ENABLE_PYRAMIDING else 'Desactivado'}"
+        )
+        log.info(
+            f"🤖 IA Analytics: {'Activado' if config.ENABLE_AI_ANALYSIS else 'Desactivado'}"
+        )
+        log.info("=" * 70)
         log.info("")
-        
+
         # Inicializar
         self.capital.update_balance(force=True)
         log.info(f"💰 Balance Inicial: {self.capital.current_balance:.2f} USDT")
         log.info("")
-        
+
         # Notificar
         if self.telegram.enabled:
             self.telegram.send_message(
@@ -2185,80 +2465,84 @@ class EnhancedTradingBot:
                 f"📈 Pyramiding: {'✅' if config.ENABLE_PYRAMIDING else '❌'}\n"
                 f"🤖 IA Analytics: {'✅' if config.ENABLE_AI_ANALYSIS else '❌'}"
             )
-        
+
         errors = 0
-        
+
         while True:
             try:
                 with state_lock:
                     if not app_state["running"]:
                         log.info("🛑 Bot detenido")
                         break
-                
+
                 # Health check del sistema
                 if self.error_handler.circuit_open:
-                    log.warning("⏸️ Circuit breaker activado - pausando operaciones")
+                    log.warning(
+                        "⏸️ Circuit breaker activado - pausando operaciones")
                     time.sleep(60)
                     continue
-                
+
                 # Actualizar balance
                 if self.cycle % 5 == 0:
                     self.capital.update_balance()
                     with state_lock:
                         app_state["balance"] = self.capital.current_balance
-                
+
                 # Análisis de condiciones de mercado
                 self._analyze_market_conditions()
-                
+
                 # Trading adaptativo
                 self._adaptive_trading()
-                
+
                 # MONITOREO MEJORADO DE POSICIONES
                 if self.cycle % 3 == 0:  # Cada 30 segundos
                     self.position_monitor.monitor_all_positions()
-                
+
                 # Escanear símbolos
                 self._scan_symbols()
-                
+
                 # Monitorear posiciones
                 self._monitor_positions()
-                
+
                 # ANÁLISIS DE PERFORMANCE
                 if self.cycle % config.PERFORMANCE_REPORT_INTERVAL == 0:
                     self._generate_performance_report()
-                
+
                 # Actualizar métricas
                 self._update_metrics()
-                
+
                 errors = 0
                 self.error_handler.record_success()
                 self.cycle += 1
                 time.sleep(config.POLL_SEC)
-            
+
             except Exception as e:
                 errors += 1
                 self.error_handler.record_error()
                 log.error(f"❌ Error ciclo {self.cycle}: {e}")
-                
+
                 if errors >= 3:
                     log.error("🚨 Muchos errores, pausando...")
                     time.sleep(30)
                     errors = 0
                 else:
                     time.sleep(15)
-    
+
     def _analyze_market_conditions(self):
         """Analizar condiciones de mercado"""
         try:
             # Calcular volatilidad del mercado
             tickers = self.api.client.futures_ticker()
-            price_changes = [float(t['priceChangePercent']) for t in tickers[:20] 
-                           if float(t['priceChangePercent']) != 0]
-            
+            price_changes = [
+                float(t["priceChangePercent"])
+                for t in tickers[:20]
+                if float(t["priceChangePercent"]) != 0
+            ]
+
             if price_changes:
                 self.market_volatility = np.std(price_changes)
                 health_monitor.market_volatility = self.market_volatility
-                
+
                 # Determinar condición del mercado
                 if self.market_volatility > 2.0:
                     app_state["market_condition"] = "HIGH_VOLATILITY"
@@ -2266,19 +2550,21 @@ class EnhancedTradingBot:
                     app_state["market_condition"] = "LOW_VOLATILITY"
                 else:
                     app_state["market_condition"] = "NORMAL"
-                    
+
                 # Log cada 50 ciclos
                 if self.cycle % 50 == 0:
-                    log.info(f"📊 Condición mercado: {app_state['market_condition']} "
-                            f"(Volatilidad: {self.market_volatility:.2f}%)")
-                    
+                    log.info(
+                        f"📊 Condición mercado: {app_state['market_condition']} "
+                        f"(Volatilidad: {self.market_volatility:.2f}%)"
+                    )
+
         except Exception as e:
             log.warning(f"⚠️ Error análisis mercado: {e}")
-    
+
     def _adaptive_trading(self):
         """Trading adaptativo a condiciones del mercado"""
         market_condition = app_state.get("market_condition", "NORMAL")
-        
+
         # Ajustar estrategia según condiciones
         if market_condition == "HIGH_VOLATILITY":
             # Reducir tamaño de posición en alta volatilidad
@@ -2288,116 +2574,139 @@ class EnhancedTradingBot:
                 log.info("📉 Alta volatilidad - Reduciendo riesgo 30%")
         elif market_condition == "LOW_VOLATILITY":
             # Estrategias para mercados tranquilos
-            config.RISK_PER_TRADE_PERCENT = min(3.0, config.RISK_PER_TRADE_PERCENT * 1.1)
-    
+            config.RISK_PER_TRADE_PERCENT = min(
+                3.0, config.RISK_PER_TRADE_PERCENT * 1.1
+            )
+
     def _scan_symbols(self):
         """Escanear símbolos mejorado"""
         try:
             account = self.api._safe_api_call(self.api.client.futures_account)
             if not account:
                 return
-            
-            open_pos = {p['symbol']: p for p in account['positions'] 
-                       if float(p['positionAmt']) != 0}
-            
+
+            open_pos = {
+                p["symbol"]: p
+                for p in account["positions"]
+                if float(p["positionAmt"]) != 0
+            }
+
             if len(open_pos) >= config.MAX_CONCURRENT_POS:
                 return
-            
+
             now = time.time()
-            
+
             for symbol in self.symbols:
                 try:
                     if symbol in open_pos:
                         continue
-                    
+
                     # Cooldown
                     if now - self.scanned.get(symbol, 0) < 120:
                         continue
-                    
+
                     self.scanned[symbol] = now
-                    
+
                     # Obtener datos
                     df = self._get_data(symbol)
                     if df is None or len(df) < 50:
                         continue
-                    
+
                     # Indicadores
                     df = self.signal_detector.calculate_indicators(df)
-                    
+
                     # Detectar señal
                     signal = self.signal_detector.detect_signal(df, symbol)
-                    
-                    if signal and signal['strength'] > config.MIN_SIGNAL_STRENGTH:
-                        log.info(f"🎯 SEÑAL: {symbol} {signal['type']} "
-                                f"(Fuerza: {signal['strength']:.0%}, Score: {signal['score']}/8)")
-                        
+
+                    if signal and signal["strength"] > config.MIN_SIGNAL_STRENGTH:
+                        log.info(
+                            f"🎯 SEÑAL: {symbol} {signal['type']} "
+                            f"(Fuerza: {signal['strength']:.0%}, Score: {signal['score']}/8)"
+                        )
+
                         # Verificar drawdown antes de abrir
                         drawdown = self.capital.get_drawdown()
                         if drawdown > config.MAX_DRAWDOWN_PCT:
-                            log.warning(f"⚠️ Drawdown alto ({drawdown:.1f}%), omitiendo señal")
+                            log.warning(
+                                f"⚠️ Drawdown alto ({drawdown:.1f}%), omitiendo señal"
+                            )
                             continue
-                        
+
                         # Abrir posición
                         if self.position_mgr.open_position(symbol, signal):
                             break
-                
+
                 except Exception as e:
                     log.error(f"Error escaneando {symbol}: {e}")
                     continue
-        
+
         except Exception as e:
             log.error(f"Error en scan: {e}")
-    
+
     def _monitor_positions(self):
         """Monitorear posiciones mejorado"""
         try:
             account = self.api._safe_api_call(self.api.client.futures_account)
             if not account:
                 return
-            
-            open_pos = {p['symbol']: p for p in account['positions'] 
-                       if float(p['positionAmt']) != 0}
-            
+
+            open_pos = {
+                p["symbol"]: p
+                for p in account["positions"]
+                if float(p["positionAmt"]) != 0
+            }
+
             with state_lock:
                 app_state["open_positions"] = open_pos
-            
+
             for symbol, pos in open_pos.items():
                 try:
-                    close_info = self.position_mgr.monitor_position(symbol, pos)
-                    if close_info and close_info.get('should_close'):
-                        self.position_mgr.close_position(symbol, pos, close_info)
-                
+                    close_info = self.position_mgr.monitor_position(
+                        symbol, pos)
+                    if close_info and close_info.get("should_close"):
+                        self.position_mgr.close_position(
+                            symbol, pos, close_info)
+
                 except Exception as e:
                     log.error(f"Error monitoreando {symbol}: {e}")
-        
+
         except Exception as e:
             log.error(f"Error en monitor: {e}")
-    
+
     def _generate_performance_report(self):
         """Generar reporte de performance periódico"""
         try:
             analysis = self.trade_logger.get_performance_analysis()
-            
-            if analysis and analysis.get('summary'):
+
+            if analysis and analysis.get("summary"):
                 log.info("📈 REPORTE DE PERFORMANCE AVANZADO:")
-                log.info(f"   Trades totales: {analysis['summary']['total_trades']}")
-                log.info(f"   Win Rate: {analysis['summary']['win_rate']:.1f}%")
-                log.info(f"   P&L Total: ${analysis['summary']['total_pnl']:.2f}")
-                log.info(f"   Profit Factor: {analysis['summary']['profit_factor']:.2f}")
-                
+                log.info(
+                    f"   Trades totales: {analysis['summary']['total_trades']}")
+                log.info(
+                    f"   Win Rate: {analysis['summary']['win_rate']:.1f}%")
+                log.info(
+                    f"   P&L Total: ${analysis['summary']['total_pnl']:.2f}")
+                log.info(
+                    f"   Profit Factor: {analysis['summary']['profit_factor']:.2f}"
+                )
+
                 # Análisis por condiciones de mercado
-                market_analysis = analysis.get('market_analysis', {})
+                market_analysis = analysis.get("market_analysis", {})
                 for condition, data in market_analysis.items():
-                    if data.get('trades', 0) > 0:
-                        log.info(f"   {condition}: {data['trades']} trades, "
-                                f"WR: {data.get('win_rate', 0):.1f}%")
-                
+                    if data.get("trades", 0) > 0:
+                        log.info(
+                            f"   {condition}: {data['trades']} trades, "
+                            f"WR: {data.get('win_rate', 0):.1f}%"
+                        )
+
                 # Log de mejores trades
-                if analysis.get('best_trades'):
-                    best = analysis['best_trades'][0]
-                    log.info(f"   🏆 Mejor trade: {best.get('symbol', 'N/A')} "
-                            f"+${best.get('pnl', 0):.2f} (Score: {best.get('signal_score', 'N/A')})")
-                
+                if analysis.get("best_trades"):
+                    best = analysis["best_trades"][0]
+                    log.info(
+                        f"   🏆 Mejor trade: {best.get('symbol', 'N/A')} "
+                        f"+${best.get('pnl', 0):.2f} (Score: {best.get('signal_score', 'N/A')})"
+                    )
+
                 # Recomendaciones IA
                 if config.ENABLE_AI_ANALYSIS:
                     recommendations = self.trading_ai.get_optimization_recommendations()
@@ -2405,10 +2714,10 @@ class EnhancedTradingBot:
                         log.info("   🤖 RECOMENDACIONES IA:")
                         for rec in recommendations[:3]:  # Mostrar solo 3
                             log.info(f"      • {rec}")
-        
+
         except Exception as e:
             log.error(f"Error generando reporte: {e}")
-    
+
     def _update_metrics(self):
         """Actualizar métricas del sistema"""
         # Actualizar health metrics cada 10 ciclos
@@ -2418,7 +2727,7 @@ class EnhancedTradingBot:
                 app_state["performance_stats"].update(
                     self.position_mgr.analytics.calculate_metrics()
                 )
-    
+
     def _get_data(self, symbol: str) -> Optional[pd.DataFrame]:
         """Obtener datos de klines - CORREGIDO"""
         try:
@@ -2426,43 +2735,57 @@ class EnhancedTradingBot:
                 self.api.client.futures_klines,
                 symbol=symbol,
                 interval=config.TIMEFRAME,
-                limit=config.CANDLES_LIMIT
+                limit=config.CANDLES_LIMIT,
             )
-            
+
             if not klines:
                 return None
-            
+
             df = pd.DataFrame(
                 klines,
-                columns=['timestamp', 'open', 'high', 'low', 'close', 'volume',
-                        'close_time', 'quote_asset_volume', 'number_of_trades',
-                        'taker_buy_base', 'taker_buy_quote', 'ignore']
+                columns=[
+                    "timestamp",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "close_time",
+                    "quote_asset_volume",
+                    "number_of_trades",
+                    "taker_buy_base",
+                    "taker_buy_quote",
+                    "ignore",
+                ],
             )
-            
-            for col in ['open', 'high', 'low', 'close', 'volume']:
-                df[col] = pd.to_numeric(df[col], errors='coerce')
-            
-            df = df.dropna(subset=['close'])
-            
-            if len(df) < 50 or (df['volume'] == 0).any():
+
+            for col in ["open", "high", "low", "close", "volume"]:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+
+            df = df.dropna(subset=["close"])
+
+            if len(df) < 50 or (df["volume"] == 0).any():
                 return None
-            
+
             return df
-        
+
         except Exception as e:
             log.error(f"Error obteniendo datos {symbol}: {e}")
             return None
+
 
 # ═══════════════════════════════════════════════════════════════════
 # RUTAS WEB MEJORADAS
 # ═══════════════════════════════════════════════════════════════════
 
-@app.route('/')
+
+@app.route("/")
 def index():
     """Página principal"""
-    return render_template('index.html')
+    return render_template("index.html")
 
-@app.route('/api/status')
+
+@app.route("/api/status")
 def api_status():
     """Estado del bot mejorado"""
     with state_lock:
@@ -2470,17 +2793,18 @@ def api_status():
         app_state["health_metrics"] = health_monitor.get_health_status()
         return jsonify(app_state)
 
-@app.route('/api/start', methods=['POST'])
+
+@app.route("/api/start", methods=["POST"])
 def api_start():
     """Iniciar bot"""
     global bot_thread
-    
+
     with state_lock:
         if app_state["running"]:
             return jsonify({"status": "error", "message": "Bot ya está corriendo"})
         app_state["running"] = True
         app_state["status_message"] = "Iniciado"
-    
+
     def run_bot():
         try:
             bot = EnhancedTradingBot()
@@ -2490,47 +2814,54 @@ def api_start():
             with state_lock:
                 app_state["running"] = False
                 app_state["status_message"] = f"Error: {str(e)}"
-    
+
     bot_thread = threading.Thread(target=run_bot, daemon=True)
     bot_thread.start()
-    
+
     log.info("✅ Bot mejorado V14.0 iniciado")
     return jsonify({"status": "success", "message": "Bot mejorado V14.0 iniciado"})
 
-@app.route('/api/stop', methods=['POST'])
+
+@app.route("/api/stop", methods=["POST"])
 def api_stop():
     """Detener bot"""
     with state_lock:
         app_state["running"] = False
         app_state["status_message"] = "Detenido"
-    
+
     log.info("🛑 Bot detenido")
     return jsonify({"status": "success", "message": "Bot detenido"})
 
-@app.route('/api/emergency_stop', methods=['POST'])
+
+@app.route("/api/emergency_stop", methods=["POST"])
 def api_emergency_stop():
     """Parada de emergencia - Cierra todas las posiciones - CORREGIDO"""
     try:
         api = BinanceFutures()
         account = api._safe_api_call(api.client.futures_account)
-        
+
         if not account:
-            return jsonify({"status": "error", "message": "No se pudo obtener información de la cuenta"})
-        
+            return jsonify(
+                {
+                    "status": "error",
+                    "message": "No se pudo obtener información de la cuenta",
+                }
+            )
+
         closed_positions = []
-        for position in account['positions']:
-            position_amt = float(position['positionAmt'])
+        for position in account["positions"]:
+            position_amt = float(position["positionAmt"])
             if position_amt != 0:
-                result = api.close_position(position['symbol'], position_amt)
+                result = api.close_position(position["symbol"], position_amt)
                 if result:
-                    closed_positions.append(position['symbol'])
+                    closed_positions.append(position["symbol"])
                     log.info(f"🆘 Cierre emergencia: {position['symbol']}")
-        
+
         # Detener bot
         with state_lock:
             app_state["running"] = False
             app_state["status_message"] = "EMERGENCY STOP"
-        
+
         # Notificar
         telegram = TelegramNotifier()
         if telegram.enabled:
@@ -2539,21 +2870,24 @@ def api_emergency_stop():
                 f"Posiciones cerradas: {len(closed_positions)}\n"
                 f"Símbolos: {', '.join(closed_positions) if closed_positions else 'Ninguna'}"
             )
-        
-        return jsonify({
-            "status": "success", 
-            "closed_positions": closed_positions,
-            "message": "Parada de emergencia ejecutada"
-        })
-    
+
+        return jsonify(
+            {
+                "status": "success",
+                "closed_positions": closed_positions,
+                "message": "Parada de emergencia ejecutada",
+            }
+        )
+
     except Exception as e:
         log.error(f"❌ Error en parada de emergencia: {e}")
         return jsonify({"status": "error", "message": str(e)})
 
-@app.route('/api/config', methods=['GET', 'POST'])
+
+@app.route("/api/config", methods=["GET", "POST"])
 def api_config():
     """Configuración mejorada"""
-    if request.method == 'POST':
+    if request.method == "POST":
         new_config = request.json
         with state_lock:
             for key, value in new_config.items():
@@ -2566,314 +2900,351 @@ def api_config():
                         value = int(value)
                     elif isinstance(current_value, float):
                         value = float(value)
-                    
+
                     setattr(config, key, value)
                     app_state["config"][key] = value
-            
+
             # Log de cambios importantes
-            if 'RISK_PER_TRADE_PERCENT' in new_config:
-                log.info(f"⚙️ Riesgo actualizado: {config.RISK_PER_TRADE_PERCENT}%")
-            if 'LEVERAGE' in new_config:
+            if "RISK_PER_TRADE_PERCENT" in new_config:
+                log.info(
+                    f"⚙️ Riesgo actualizado: {config.RISK_PER_TRADE_PERCENT}%")
+            if "LEVERAGE" in new_config:
                 log.info(f"⚙️ Leverage actualizado: {config.LEVERAGE}x")
-        
+
         return jsonify({"status": "success", "message": "Configuración actualizada"})
-    
+
     with state_lock:
         return jsonify(app_state["config"])
 
-@app.route('/api/advanced_config', methods=['POST'])
+
+@app.route("/api/advanced_config", methods=["POST"])
 def api_advanced_config():
     """Configuración avanzada en tiempo real"""
     try:
         new_config = request.json
-        
+
         # Validar configuración
-        valid_keys = ['TRADING_HOURS', 'MAX_DRAWDOWN_PCT', 'AUTO_RISK_ADJUSTMENT', 
-                     'ENABLE_PYRAMIDING', 'MAX_PYRAMID_LEVELS', 'ENABLE_AI_ANALYSIS',
-                     'SAVE_TRADE_CSV', 'PERFORMANCE_REPORT_INTERVAL']
-        config_updates = {k: v for k, v in new_config.items() if k in valid_keys}
-        
+        valid_keys = [
+            "TRADING_HOURS",
+            "MAX_DRAWDOWN_PCT",
+            "AUTO_RISK_ADJUSTMENT",
+            "ENABLE_PYRAMIDING",
+            "MAX_PYRAMID_LEVELS",
+            "ENABLE_AI_ANALYSIS",
+            "SAVE_TRADE_CSV",
+            "PERFORMANCE_REPORT_INTERVAL",
+        ]
+        config_updates = {k: v for k,
+                          v in new_config.items() if k in valid_keys}
+
         with state_lock:
             # Actualizar configuración global
             for key, value in config_updates.items():
                 if hasattr(config, key):
                     setattr(config, key, value)
                     app_state["config"][key] = value
-            
+
             # Aplicar cambios en caliente
-            if 'TRADING_HOURS' in config_updates:
-                log.info(f"🕒 Horario de trading actualizado: {config.TRADING_HOURS}")
-            if 'ENABLE_PYRAMIDING' in config_updates:
+            if "TRADING_HOURS" in config_updates:
+                log.info(
+                    f"🕒 Horario de trading actualizado: {config.TRADING_HOURS}")
+            if "ENABLE_PYRAMIDING" in config_updates:
                 status = "activado" if config.ENABLE_PYRAMIDING else "desactivado"
                 log.info(f"📈 Pyramiding {status}")
-            if 'ENABLE_AI_ANALYSIS' in config_updates:
+            if "ENABLE_AI_ANALYSIS" in config_updates:
                 status = "activado" if config.ENABLE_AI_ANALYSIS else "desactivado"
                 log.info(f"🤖 Análisis IA {status}")
-        
+
         return jsonify({"status": "success", "applied": config_updates})
-    
+
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)})
 
-@app.route('/api/positions')
+
+@app.route("/api/positions")
 def api_positions():
     """Posiciones abiertas"""
     with state_lock:
         return jsonify(app_state["open_positions"])
 
-@app.route('/api/history')
+
+@app.route("/api/history")
 def api_history():
     """Historial de trades"""
     with state_lock:
         return jsonify({"trades": app_state.get("trades_history", [])})
 
-@app.route('/api/performance')
+
+@app.route("/api/performance")
 def api_performance():
     """Métricas de performance detalladas (CORREGIDO)"""
     try:
         analytics = AnalyticsEngine()
         metrics = analytics.calculate_metrics()
-        
+
         health_status = health_monitor.get_health_status()
-        
-        return jsonify({
-            "metrics": metrics,
-            "health": health_status,
-            "current_strategy": {
-                "active_symbols": list(app_state.get("open_positions", {}).keys()),
-                "market_condition": app_state.get("market_condition", "NORMAL"),
-                "volatility": getattr(health_monitor, 'market_volatility', 0)
+
+        return jsonify(
+            {
+                "metrics": metrics,
+                "health": health_status,
+                "current_strategy": {
+                    "active_symbols": list(app_state.get("open_positions", {}).keys()),
+                    "market_condition": app_state.get("market_condition", "NORMAL"),
+                    "volatility": getattr(health_monitor, "market_volatility", 0),
+                },
             }
-        })
-    
+        )
+
     except Exception as e:
         log.error(f"Error en endpoint de performance: {e}")
-        return jsonify({
-            "metrics": {},
-            "health": {"error": str(e)},
-            "current_strategy": {}
-        })
+        return jsonify(
+            {"metrics": {}, "health": {
+                "error": str(e)}, "current_strategy": {}}
+        )
+
 
 # ═══════════════════════════════════════════════════════════════════
 # NUEVAS RUTAS API PARA ANÁLISIS AVANZADO
 # ═══════════════════════════════════════════════════════════════════
 
-@app.route('/api/advanced_analytics')
+
+@app.route("/api/advanced_analytics")
 def api_advanced_analytics():
     """Analíticas avanzadas de trading"""
     try:
         # Inicializar si no existe
-        if not hasattr(app, 'trade_logger'):
+        if not hasattr(app, "trade_logger"):
             app.trade_logger = AdvancedTradeLogger()
-        
-        if not hasattr(app, 'trading_ai'):
+
+        if not hasattr(app, "trading_ai"):
             app.trading_ai = TradingAI()
-        
+
         analysis = app.trade_logger.get_performance_analysis()
         recommendations = app.trading_ai.get_optimization_recommendations()
-        
-        return jsonify({
-            "status": "success",
-            "performance_analysis": analysis,
-            "ai_recommendations": recommendations,
-            "model_weights": app.trading_ai.model_weights,
-            "detected_patterns": app.trading_ai.patterns_detected[-10:]  # últimos 10 patrones
-        })
-    
+
+        return jsonify(
+            {
+                "status": "success",
+                "performance_analysis": analysis,
+                "ai_recommendations": recommendations,
+                "model_weights": app.trading_ai.model_weights,
+                "detected_patterns": app.trading_ai.patterns_detected[
+                    -10:
+                ],  # últimos 10 patrones
+            }
+        )
+
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)})
 
-@app.route('/api/trade_history_detailed')
+
+@app.route("/api/trade_history_detailed")
 def api_trade_history_detailed():
     """Historial detallado de trades"""
     try:
-        if not hasattr(app, 'trade_logger'):
+        if not hasattr(app, "trade_logger"):
             return jsonify({"trades": []})
-        
-        return jsonify({
-            "trades": app.trade_logger.trade_history[-50:],  # últimos 50 trades
-            "best_trades": app.trade_logger.best_trades,
-            "worst_trades": app.trade_logger.worst_trades
-        })
-    
+
+        return jsonify(
+            {
+                # últimos 50 trades
+                "trades": app.trade_logger.trade_history[-50:],
+                "best_trades": app.trade_logger.best_trades,
+                "worst_trades": app.trade_logger.worst_trades,
+            }
+        )
+
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)})
 
-@app.route('/api/position_analysis')
+
+@app.route("/api/position_analysis")
 def api_position_analysis():
     """Análisis en tiempo real de posiciones"""
     try:
         # Crear instancia temporal para análisis
-        if not hasattr(app, 'position_monitor'):
+        if not hasattr(app, "position_monitor"):
             api = BinanceFutures()
             capital = CapitalManager(api)
             app.position_monitor = EnhancedPositionMonitor(api, capital)
-        
+
         # Ejecutar análisis actual
         app.position_monitor.monitor_all_positions()
-        
-        return jsonify({
-            "positions_snapshot": app.position_monitor.positions_snapshot,
-            "performance_alerts": app.position_monitor.performance_alerts,
-            "market_condition": app_state.get("market_condition", "NORMAL")
-        })
-    
+
+        return jsonify(
+            {
+                "positions_snapshot": app.position_monitor.positions_snapshot,
+                "performance_alerts": app.position_monitor.performance_alerts,
+                "market_condition": app_state.get("market_condition", "NORMAL"),
+            }
+        )
+
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)})
 
-@app.route('/api/health')
+
+@app.route("/api/health")
 def api_health():
     """Endpoint de salud del sistema"""
     try:
         process = psutil.Process()
         memory_usage = process.memory_info().rss / 1024 / 1024
-        
-        return jsonify({
-            "status": "healthy",
-            "timestamp": datetime.now().isoformat(),
-            "uptime": health_monitor.get_uptime(),
-            "memory_usage": f"{memory_usage:.2f} MB",
-            "active_threads": threading.active_count(),
-            "cpu_percent": psutil.cpu_percent(),
-            "bot_cycles": getattr(health_monitor, 'cycle', 0)
-        })
-    except Exception as e:
-        return jsonify({
-            "status": "error",
-            "error": str(e)
-        })
 
-@app.route('/api/optimize', methods=['POST'])
+        return jsonify(
+            {
+                "status": "healthy",
+                "timestamp": datetime.now().isoformat(),
+                "uptime": health_monitor.get_uptime(),
+                "memory_usage": f"{memory_usage:.2f} MB",
+                "active_threads": threading.active_count(),
+                "cpu_percent": psutil.cpu_percent(),
+                "bot_cycles": getattr(health_monitor, "cycle", 0),
+            }
+        )
+    except Exception as e:
+        return jsonify({"status": "error", "error": str(e)})
+
+
+@app.route("/api/optimize", methods=["POST"])
 def api_optimize():
     """Optimizar parámetros del bot"""
     data = request.json
-    symbol = data.get('symbol', 'BTCUSDT')
-    days = data.get('days', 30)
-    
+    symbol = data.get("symbol", "BTCUSDT")
+    days = data.get("days", 30)
+
     try:
         backtester = Backtester(BinanceFutures())
         results = backtester.run_backtest(symbol, days)
-        
+
         if results:
-            return jsonify({
-                "status": "success", 
-                "optimization": results,
-                "symbol": symbol,
-                "period_days": days
-            })
+            return jsonify(
+                {
+                    "status": "success",
+                    "optimization": results,
+                    "symbol": symbol,
+                    "period_days": days,
+                }
+            )
         else:
             return jsonify({"status": "error", "message": "Error en backtesting"})
-    
+
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)})
 
-@app.route('/api/close_position', methods=['POST'])
+
+@app.route("/api/close_position", methods=["POST"])
 def api_close_position():
     """Cerrar posición manualmente"""
     try:
         data = request.json
-        symbol = data.get('symbol')
-        
+        symbol = data.get("symbol")
+
         with state_lock:
             if symbol not in app_state["open_positions"]:
                 return jsonify({"status": "error", "message": "Posición no encontrada"})
             position = app_state["open_positions"][symbol]
-        
+
         api = BinanceFutures()
-        result = api.close_position(symbol, float(position['positionAmt']))
-        
+        result = api.close_position(symbol, float(position["positionAmt"]))
+
         if result:
             log.info(f"✅ Posición {symbol} cerrada manualmente")
-            return jsonify({"status": "success", "message": f"Posición {symbol} cerrada"})
+            return jsonify(
+                {"status": "success", "message": f"Posición {symbol} cerrada"}
+            )
         else:
             return jsonify({"status": "error", "message": "Error cerrando posición"})
-    
+
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)})
 
-@socketio.on('connect')
+
+@socketio.on("connect")
 def handle_connect():
     """Cliente conectado"""
-    log.info('📱 Cliente WebSocket conectado')
-    socketio.emit('status_update', app_state)
+    log.info("📱 Cliente WebSocket conectado")
+    socketio.emit("status_update", app_state)
 
-@socketio.on('disconnect')
+
+@socketio.on("disconnect")
 def handle_disconnect():
     """Cliente desconectado"""
-    log.info('📱 Cliente WebSocket desconectado')
+    log.info("📱 Cliente WebSocket desconectado")
 
-@socketio.on('get_health')
+
+@socketio.on("get_health")
 def handle_health():
     """Solicitud de salud"""
-    socketio.emit('health_update', health_monitor.get_health_status())
+    socketio.emit("health_update", health_monitor.get_health_status())
+
 
 # ═══════════════════════════════════════════════════════════════════
 # INICIALIZACIÓN MEJORADA (CORREGIDO)
 # ═══════════════════════════════════════════════════════════════════
 
+
 def enhanced_initialize():
     """Inicialización mejorada"""
     try:
         log.info("🚀 INICIALIZACIÓN AVANZADA DEL SISTEMA V14.0")
-        
+
         # Verificar dependencias
         try:
             import psutil
+
             log.info("✅ Dependencias avanzadas cargadas")
         except ImportError as e:
             log.warning(f"⚠️ Dependencia faltante: {e}")
-        
+
         # Inicializar API
         api = BinanceFutures()
         log.info("✅ Conexión Binance OK")
-        
+
         # Inicializar capital
         capital = CapitalManager(api)
         if capital.update_balance(force=True):
             log.info(f"💰 Balance: {capital.current_balance:.2f} USDT")
             with state_lock:
                 app_state["balance"] = capital.current_balance
-        
+
         # Inicializar sistemas avanzados
         app.trade_logger = AdvancedTradeLogger()
         app.trading_ai = TradingAI()
         log.info("✅ Sistemas IA y Analytics inicializados")
-        
+
         # Actualizar health metrics inicial
         with state_lock:
             app_state["health_metrics"] = health_monitor.get_health_status()
-        
+
         log.info("✅ Sistema avanzado V14.0 inicializado correctamente")
         return True
-        
+
     except Exception as e:
         log.error(f"❌ Error inicialización avanzada: {e}")
         return False
+
 
 # ═══════════════════════════════════════════════════════════════════
 # MAIN
 # ═══════════════════════════════════════════════════════════════════
 
 if __name__ == "__main__":
-    log.info("="*70)
+    log.info("=" * 70)
     log.info("🚀 BINANCE FUTURES BOT V14.0 - SISTEMA MEJORADO CON IA")
-    log.info("="*70)
-    
+    log.info("=" * 70)
+
     if not enhanced_initialize():
         log.error("❌ Inicialización fallida")
         exit(1)
-    
+
     try:
         log.info("🌐 Servidor: http://0.0.0.0:5000")
         log.info("📊 Dashboard: http://localhost:5000")
         log.info("🔧 Características avanzadas: ✅ ACTIVADAS")
         log.info("🤖 Análisis IA: ✅ ACTIVADO")
         socketio.run(
-            app, 
-            host='0.0.0.0', 
-            port=5000, 
-            debug=True,
-            allow_unsafe_werkzeug=True
+            app, host="0.0.0.0", port=5000, debug=True, allow_unsafe_werkzeug=True
         )
     except Exception as e:
         log.error(f"❌ Error servidor: {e}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- add optional fallbacks for third party imports so the test environment can import the trading app without extra dependencies
- implement candle pattern detection helpers and an improved risk manager used by the unit tests while enhancing capital tracking
- limit pytest discovery to the maintained test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb03ac286c83298403157fa1e8b187